### PR TITLE
fix(theme): build the cookie per request, not at module scope

### DIFF
--- a/app/color-scheme-cookie.ts
+++ b/app/color-scheme-cookie.ts
@@ -1,38 +1,7 @@
 import { createCookie } from "react-router";
 import { createTypedCookie } from "remix-utils/typed-cookie";
 import { z } from "zod";
-
-/**
- * The one place that reads `process.env` instead of the request-scoped
- * `cloudflareContext`: `createCookie` runs at module scope, before any request
- * exists. `wrangler types` declares these on `NodeJS.ProcessEnv`, and the
- * runtime populates them from vars and secrets.
- *
- * Missing values throw at startup rather than defaulting. A signing secret that
- * silently falls back is worse than a Worker that refuses to boot: the site
- * keeps working while every cookie is signed with a value anyone can read.
- */
-function requireEnv(name: "SESSION_THEME_SECRET" | "DEPLOYMENT_ENV"): string {
-  const value = process.env[name];
-
-  if (!value) {
-    throw new Error(`Missing env: ${name}`);
-  }
-
-  return value;
-}
-
-const isProduction = requireEnv("DEPLOYMENT_ENV") === "production";
-
-// Create a cookie using React Router's createCookie API
-const cookie = createCookie("poschuler__color-scheme", {
-  path: "/",
-  sameSite: "lax",
-  httpOnly: true,
-  maxAge: 30 * 24 * 60 * 60,
-  secrets: [requireEnv("SESSION_THEME_SECRET")],
-  ...(isProduction ? { domain: "poschuler.com", secure: true } : {}),
-});
+import type { AppEnv } from "~/context";
 
 // Create a Zod schema to validate the cookie value
 export const schema = z
@@ -42,15 +11,58 @@ export const schema = z
 
 export type ColorScheme = z.infer<typeof schema>;
 
-// Use Remix Utils to ensure the cookie value is always parsed
-const typedCookie = createTypedCookie({ cookie, schema });
+/**
+ * Built per request, from the request-scoped `env` — never at module scope.
+ *
+ * An earlier version read `process.env` while the module was being evaluated
+ * and threw on a missing value. That turned a missing var into a Worker that
+ * threw on *every* request, taking the whole site down to protect a theme
+ * preference. Bindings are request-scoped here; read them that way.
+ */
+function colorSchemeCookie(env: AppEnv) {
+  if (!env.SESSION_THEME_SECRET) {
+    throw new Error("Missing env: SESSION_THEME_SECRET");
+  }
 
-// Helpers to get and set the cookie
-export async function getColorScheme(request: Request): Promise<ColorScheme> {
-  const colorScheme = await typedCookie.parse(request.headers.get("Cookie"));
-  return colorScheme ?? "system";
+  const isProduction = env.DEPLOYMENT_ENV === "production";
+
+  const cookie = createCookie("poschuler__color-scheme", {
+    path: "/",
+    sameSite: "lax",
+    httpOnly: true,
+    maxAge: 30 * 24 * 60 * 60,
+    secrets: [env.SESSION_THEME_SECRET],
+    ...(isProduction ? { domain: "poschuler.com", secure: true } : {}),
+  });
+
+  return createTypedCookie({ cookie, schema });
 }
 
-export async function setColorScheme(colorScheme: ColorScheme) {
-  return await typedCookie.serialize(colorScheme);
+/**
+ * Reading degrades: a misconfigured Worker still serves every page, in the
+ * default theme, and says so in the logs. Writing does not — see below.
+ */
+export async function getColorScheme(
+  request: Request,
+  env: AppEnv
+): Promise<ColorScheme> {
+  try {
+    const colorScheme = await colorSchemeCookie(env).parse(
+      request.headers.get("Cookie")
+    );
+
+    return colorScheme ?? "system";
+  } catch (error) {
+    console.error("Could not read the colour scheme cookie", error);
+    return "system";
+  }
+}
+
+/**
+ * Writing throws on a missing secret rather than falling back. A cookie signed
+ * with a placeholder is worse than a toggle that visibly fails: the failure is
+ * confined to this one endpoint, and the rest of the site is unaffected.
+ */
+export async function setColorScheme(colorScheme: ColorScheme, env: AppEnv) {
+  return await colorSchemeCookie(env).serialize(colorScheme);
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -11,6 +11,7 @@ import {
 import type { Route } from "./+types/root";
 import "./app.css";
 import { getColorScheme } from "./color-scheme-cookie";
+import { cloudflareContext } from "./context";
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -28,8 +29,10 @@ export const links: Route.LinksFunction = () => [
 // No `meta` here on purpose: a route that forgets its own `meta` should render
 // with none at all, rather than silently inheriting the home page's title.
 
-export async function loader({ request }: Route.LoaderArgs) {
-  return { colorScheme: await getColorScheme(request) };
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const { env } = context.get(cloudflareContext);
+
+  return { colorScheme: await getColorScheme(request, env) };
 }
 
 /**

--- a/app/routes/set-theme.ts
+++ b/app/routes/set-theme.ts
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/set-theme";
 import { redirect } from "react-router";
 import { schema, setColorScheme } from "~/color-scheme-cookie";
+import { cloudflareContext } from "~/context";
 
 /**
  * Where to send the browser after the cookie is written.
@@ -31,7 +32,8 @@ function backTo(request: Request): string {
 // Resource route: the theme toggle lives in the global header, so it needs a
 // fixed endpoint to POST to (a plain `Form method="POST"` would hit whatever
 // route is currently rendered). No default export — action only.
-export async function action({ request }: Route.ActionArgs) {
+export async function action({ request, context }: Route.ActionArgs) {
+  const { env } = context.get(cloudflareContext);
   const formData = await request.formData();
   const colorScheme = schema.parse(formData.get("color-scheme"));
 
@@ -39,6 +41,6 @@ export async function action({ request }: Route.ActionArgs) {
   // only while JavaScript is around to swallow it: without it the browser
   // navigates here and stays on a page reading `null`.
   return redirect(backTo(request), {
-    headers: { "Set-Cookie": await setColorScheme(colorScheme) },
+    headers: { "Set-Cookie": await setColorScheme(colorScheme, env) },
   });
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,9 @@ Cloudflare Worker  (workers/app.ts → createRequestHandler)
 
 `workers/app.ts` is the only entry point. Per request it builds a `RouterContextProvider`, sets the `cloudflareContext` declared in `app/context.ts`, and hands it to the request handler; loaders then read bindings with `const { env } = context.get(cloudflareContext)`. There is no module-level singleton holding a binding — the Workers runtime forbids capturing request-scoped state across requests.
 
-The one exception is `app/color-scheme-cookie.ts`, which reads `process.env` because `createCookie` runs at module scope, before any request exists. It reads through a `requireEnv` helper that throws on a missing value, so a deploy without `SESSION_THEME_SECRET` fails to boot instead of quietly signing cookies with a placeholder.
+**No exceptions, and one of them was paid for.** `app/color-scheme-cookie.ts` briefly built its cookie at module scope from `process.env`, throwing on a missing value. It took production down: the module is evaluated on the way to serving *any* request, so a missing var meant error 1101 on every route — the whole site off to protect a theme preference. The cookie is now built per request from the `env` in `cloudflareContext`, like everything else.
+
+Two rules came out of it. **Read bindings inside the request, never at module scope** — what works in dev, where the Vite plugin populates `process.env` from `.dev.vars`, is not what runs at the edge. And **size the blast radius to the feature**: reading the cookie degrades to the default theme and logs, while writing it still throws, so a misconfigured Worker serves every page and only the toggle fails.
 
 `app/context.ts` also owns the `AppEnv` type: the bindings `wrangler types` generates from `wrangler.jsonc` intersected with the vars that only exist in `.dev.vars`/secrets. Adding a binding means editing `wrangler.jsonc` and regenerating; adding a var means editing `AppEnv` by hand.
 


### PR DESCRIPTION
Production returned error 1101 — a JavaScript exception — on every route. The cause was the previous commit: `requireEnv` ran while the module was being evaluated, which happens on the way to serving any request, so a missing `SESSION_THEME_SECRET` took the entire site down to protect a theme preference.

The cookie is now built per request from the `env` in `cloudflareContext`, the same way every other binding in this codebase is read. That also removes the dependency on `process.env` being populated during module evaluation, which holds in dev — the Vite plugin fills it from `.dev.vars` — and is not something to rely on at the edge.

The blast radius now matches the feature. Reading the cookie falls back to the default theme and logs the failure, so every page still serves; writing it still throws, because a cookie signed with a placeholder is worse than a toggle that visibly fails.

Verified by reproducing the outage: a clean clone with no vars at all served `/resume` with `class="system"` while only `POST /set-theme` returned 500, logging `Missing env: SESSION_THEME_SECRET`.