### PR TITLE
fix(config): move non-secret config into wrangler.jsonc, drop robots.…

### DIFF
--- a/.vars.template
+++ b/.vars.template
@@ -1,4 +1,13 @@
+# Copy to `.dev.vars` and fill in. Only what a dev machine needs:
+#
+#   - SESSION_THEME_SECRET is a real secret, so it is never in git. In
+#     production it is set with `wrangler secret put`.
+#   - DEPLOYMENT_ENV overrides the "production" value in wrangler.jsonc, which
+#     is what keeps the theme cookie off `Secure` and `.poschuler.com` locally.
+#
+# PUBLIC_HOST is not listed: it lives in wrangler.jsonc, and robots.txt falls
+# back to the origin the request arrived on anyway.
+
 SESSION_THEME_SECRET=
 DB_DEBUG_FLAG=0
-PUBLIC_HOST="https://poschuler.com"
 DEPLOYMENT_ENV="development"

--- a/app/context.ts
+++ b/app/context.ts
@@ -1,15 +1,19 @@
 import { createContext } from "react-router";
 
 /**
- * The Worker environment: the bindings `wrangler types` generates from
- * `wrangler.jsonc` (KV, D1), plus the vars supplied through `.dev.vars`
- * locally and secrets in production, which Wrangler cannot infer.
+ * The Worker environment.
+ *
+ * `Env` already covers everything declared in `wrangler.jsonc` — the KV and D1
+ * bindings, and the `vars` block — because `wrangler types` reads that file.
+ * What it cannot see is the secrets: on a machine with `.dev.vars` it infers
+ * them, and on a clean clone (CI) it does not. Declaring them here is what
+ * keeps a fresh checkout type-checking.
  */
 export type AppEnv = Env & {
+  /** Secret. Signs the theme cookie. */
   SESSION_THEME_SECRET: string;
-  DB_DEBUG_FLAG: number;
-  PUBLIC_HOST: string;
-  DEPLOYMENT_ENV: string;
+  /** Declared, currently unread. */
+  DB_DEBUG_FLAG: string;
 };
 
 export type CloudflareContext = {

--- a/app/routes/robots.ts
+++ b/app/routes/robots.ts
@@ -2,14 +2,32 @@ import { generateRobotsTxt } from "~/lib/seo/robots";
 import { type LoaderFunctionArgs } from "react-router";
 import { cloudflareContext } from "~/context";
 
-export async function loader({ context }: LoaderFunctionArgs) {
-  const { env } = context.get(cloudflareContext);
-
-  if (typeof env.PUBLIC_HOST !== "string") {
-    throw new Error("Missing env: PUBLIC_HOST");
+/**
+ * The canonical origin, or the one this request arrived on.
+ *
+ * `PUBLIC_HOST` used to be required, and throwing when it was unset meant this
+ * route answered 500 on every request — invisibly, because Cloudflare's managed
+ * robots.txt filled the gap and looked like a working answer. A robots.txt can
+ * always name its own origin, so there is no reason for it to have a failure
+ * mode at all.
+ */
+function resolveOrigin(configured: string | undefined, requestUrl: string): string {
+  if (configured) {
+    try {
+      return new URL(configured).origin;
+    } catch {
+      // A value without a scheme — "poschuler.com" — is not a URL. Say so, and
+      // carry on rather than taking the route down over it.
+      console.error(`Ignoring malformed PUBLIC_HOST: ${configured}`);
+    }
   }
 
-  const baseUrl = new URL(env.PUBLIC_HOST);
+  return new URL(requestUrl).origin;
+}
+
+export async function loader({ request, context }: LoaderFunctionArgs) {
+  const { env } = context.get(cloudflareContext);
+  const origin = resolveOrigin(env.PUBLIC_HOST, request.url);
 
   // Every environment advertises itself as fully indexable. That is fine while
   // `workers_dev` is off and production is the only deployed origin; a preview
@@ -19,7 +37,7 @@ export async function loader({ context }: LoaderFunctionArgs) {
       userAgent: "*",
       allow: ["/"],
       disallow: [],
-      sitemap: [`${baseUrl.origin}/sitemap.xml`],
+      sitemap: [`${origin}/sitemap.xml`],
     },
   ]);
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,7 @@ Routes are declared explicitly in `app/routes.ts` (config-based, not file-system
 | `/resume`        | none   | none           | `app/routes/resume/resume.json`, imported at build time |
 | `/resume.pdf`    | fetch  | 1 day          | proxies `cdn.poschuler.dev`, forces `Content-Disposition: attachment` |
 | `/sitemap.xml`   | KV     | 1 hour         | serves the pre-generated XML verbatim       |
-| `/robots.txt`    | none   | 1 hour         | generated per request from `PUBLIC_HOST`    |
+| `/robots.txt`    | none   | 1 hour         | `PUBLIC_HOST`, or the request's own origin  |
 | `/set-theme`     | cookie | none           | writes the cookie, then redirects back      |
 | `*`              | none   | none           | 404, inside the layout so it keeps the header |
 
@@ -126,16 +126,20 @@ Two layers, and the split between them is deliberate.
 
 `wrangler.jsonc` declares the bindings, `nodejs_compat`, and observability (logs and traces persisted at full sampling). `workers_dev` is off — the site is served from its own domain only.
 
-Vars, templated in `.vars.template` and supplied through `.dev.vars` locally / secrets in production:
+**Configuration splits on one question: is the value secret?**
 
-| Var                    | Used by                                                   |
-| ---------------------- | --------------------------------------------------------- |
-| `SESSION_THEME_SECRET` | signs the `poschuler__color-scheme` cookie; **startup throws if missing** |
-| `DEPLOYMENT_ENV`       | `"production"` tightens the theme cookie to `poschuler.com` + `secure`; **startup throws if missing** |
-| `PUBLIC_HOST`          | canonical origin for `robots.txt`; the loader throws if unset |
-| `DB_DEBUG_FLAG`        | declared, currently unread                                 |
+| Value                  | Where it lives            | Used by                                                     |
+| ---------------------- | ------------------------- | ----------------------------------------------------------- |
+| `SESSION_THEME_SECRET` | secret (`wrangler secret`) | signs the `poschuler__color-scheme` cookie                   |
+| `DEPLOYMENT_ENV`       | `vars` in `wrangler.jsonc` | `"production"` gives the theme cookie `Secure` + its domain  |
+| `PUBLIC_HOST`          | `vars` in `wrangler.jsonc` | canonical origin in `robots.txt`                             |
+| `DB_DEBUG_FLAG`        | `.dev.vars` only           | declared, currently unread                                   |
 
-The first two are read at module scope by `color-scheme-cookie.ts`, so a missing value fails the Worker's startup check and the deploy with it. That is the intent: the alternative is a site that serves happily while signing every cookie with a placeholder.
+Non-secret values belong in `wrangler.jsonc`, in git, where a deploy cannot forget them and a new environment needs no manual step. Only the signing secret is invisible to the repository. `.dev.vars` overrides both locally — that is how `DEPLOYMENT_ENV` becomes `"development"` on a dev machine, keeping the cookie off `Secure` and off `.poschuler.com`.
+
+**A secret shadows a var of the same name in production.** If a var in `wrangler.jsonc` appears to have no effect, check `wrangler secret list` before anything else.
+
+Neither is required to boot. `SESSION_THEME_SECRET` throws only when the cookie is written, and `robots.txt` falls back to the request's own origin. Both limits were learned the hard way — see the note under Shape, and the `robots.txt` entry under Known defects.
 
 `pnpm run deploy` builds and ships in one step. Type generation (`wrangler types` + `react-router typegen`) runs on `postinstall` and before `typecheck`; the generated `worker-configuration.d.ts` and `.react-router/` are gitignored, so a fresh clone must install before it type-checks.
 
@@ -151,6 +155,7 @@ The first two are read at module scope by `color-scheme-cookie.ts`, so a missing
 - **The sitemap's `/resume` `lastmod` is the hardcoded string `2025-12-21`.**
 - **`generate-kv-json.ts` carries two near-identical fetchers**, `fetchSlugs` and `fetchAll`, differing only in a `where` clause. Only `fetchAll` is called.
 - **Nothing runs `typecheck` automatically.** There are no tests and no CI: `.github/` does not exist. `pnpm run typecheck` passes today, but only because someone remembers to run it.
+- **Cloudflare prepends a managed `robots.txt`.** The zone has AI Crawl Control's managed robots.txt on, which blocks the AI training crawlers and adds Content Signals. It merges with this Worker's response *only when the origin answers 200* — while `/robots.txt` was throwing on a missing `PUBLIC_HOST`, Cloudflare's block was served alone and the failure was invisible, `Sitemap:` line and all. If that line ever disappears again, request the route directly before suspecting the dashboard.
 - **Post HTML is never sanitised.** `marked` passes raw HTML in Markdown straight through, and the route injects the result with `dangerouslySetInnerHTML`. The only author is Paul and every file is reviewed in git, so the exposure is self-inflicted rather than remote — and the CSP now blocks the script vector. Sanitising at seed time (the pipeline, not the Worker) is the fix if that ever stops being true.
 
 ## Inherited code (removed)

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -39,7 +39,23 @@
 			"id": "a83bad39c6e54c40853d62aa6c80f28b",
 			"remote": false
 		}
-	]
+	],
+	/**
+	 * Non-sensitive configuration lives here, in git, so a deploy cannot forget
+	 * it and a new environment needs no manual step. Only genuinely secret
+	 * values — currently just SESSION_THEME_SECRET, which signs the theme
+	 * cookie — go through `wrangler secret put`.
+	 *
+	 * `.dev.vars` overrides these locally, which is how DEPLOYMENT_ENV becomes
+	 * "development" on a dev machine.
+	 *
+	 * Note: a secret shadows a var of the same name in production. If either of
+	 * these ever stops taking effect, check `wrangler secret list` first.
+	 */
+	"vars": {
+		"DEPLOYMENT_ENV": "production",
+		"PUBLIC_HOST": "https://poschuler.com"
+	}
 	/**
 	 * Smart Placement
 	 * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement


### PR DESCRIPTION
…txt's failure mode

`/robots.txt` had been answering 500 in production, on every request, since `PUBLIC_HOST` was never set — invisibly, because Cloudflare's managed robots.txt only merges with the origin's when the origin answers 200, so its block was served alone and looked like a working robots.txt. The casualty was the `Sitemap:` line, which is the whole point of the route.

Two changes, one per cause.

The route no longer depends on the var: a robots.txt can always name the origin the request arrived on, so `PUBLIC_HOST` is now an override rather than a requirement, and a malformed value is logged instead of thrown.

`DEPLOYMENT_ENV` and `PUBLIC_HOST` move to `vars` in `wrangler.jsonc`. Neither is secret — one is "production", the other is the public domain — and keeping them in git means a deploy cannot forget them and a new environment needs no manual step. Only `SESSION_THEME_SECRET` stays a secret. Note that a secret shadows a var of the same name in production, so the two that were set with `wrangler secret put` have to be deleted for these to take effect.

`AppEnv` now only declares what `wrangler types` cannot see: the secrets. The vars come from `wrangler.jsonc`, so a clean clone type-checks without a `.dev.vars` — verified, along with `robots.txt` answering 200 both with the var and with no `PUBLIC_HOST` anywhere, falling back to the request origin.