### PR TITLE
fix(theme): prefix the colour scheme cookie with __Host-

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cp .vars.template .dev.vars        # then fill SESSION_THEME_SECRET
 openssl rand -base64 32            # a value for it
 ```
 
-`SESSION_THEME_SECRET` and `DEPLOYMENT_ENV` are read at startup and **throw if missing** — the theme cookie is signed with the first, and a Worker that cannot sign it should not boot.
+`SESSION_THEME_SECRET` signs the theme cookie. Nothing reads it at startup: without it the site still serves every page in the default theme, and only the toggle itself fails.
 
 Create the local D1 table, then seed the two stores **in that order** — the KV generator reads the already-seeded D1 table to decide which Posts to render:
 

--- a/app/color-scheme-cookie.ts
+++ b/app/color-scheme-cookie.ts
@@ -19,20 +19,41 @@ export type ColorScheme = z.infer<typeof schema>;
  * threw on *every* request, taking the whole site down to protect a theme
  * preference. Bindings are request-scoped here; read them that way.
  */
+/**
+ * The `__Host-` prefix is not decoration: browsers refuse a cookie carrying it
+ * unless it is `Secure`, has `Path=/` and has **no** `Domain`. That last one is
+ * the point.
+ *
+ * The predecessor, `poschuler__color-scheme`, was emitted host-only while
+ * `DEPLOYMENT_ENV` was unset in production and gained `Domain=poschuler.com`
+ * the day that var was finally deployed. A browser treats those as two separate
+ * cookies of the same name, sends both, and whoever parses reads whichever
+ * arrives first — so every returning visitor had their theme frozen at the old
+ * value while each click wrote the new one somewhere it would never be read.
+ *
+ * Quitting `domain` would have fixed that instance by relying on the browser
+ * ordering same-path cookies oldest-first. This forbids the whole class
+ * instead: nobody can reintroduce a second scope, because the browser would
+ * reject the cookie outright rather than quietly shadowing the first.
+ *
+ * Renaming also settles the existing duplicates — nothing holds this name yet —
+ * at the cost of resetting everyone's preference once. The other cost is that
+ * `Secure` is now unconditional: `localhost` counts as a secure origin, so dev
+ * and preview are fine, but reaching a dev server over plain http on a LAN
+ * address will not persist a theme.
+ */
 function colorSchemeCookie(env: AppEnv) {
   if (!env.SESSION_THEME_SECRET) {
     throw new Error("Missing env: SESSION_THEME_SECRET");
   }
 
-  const isProduction = env.DEPLOYMENT_ENV === "production";
-
-  const cookie = createCookie("poschuler__color-scheme", {
+  const cookie = createCookie("__Host-poschuler-color-scheme", {
     path: "/",
     sameSite: "lax",
     httpOnly: true,
+    secure: true,
     maxAge: 30 * 24 * 60 * 60,
     secrets: [env.SESSION_THEME_SECRET],
-    ...(isProduction ? { domain: "poschuler.com", secure: true } : {}),
   });
 
   return createTypedCookie({ cookie, schema });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ pnpm run d1:seed:local    # generate seed.sql, then wrangler d1 execute --local
 pnpm run kv:seed:local    # generate JSON payloads, then wrangler kv key put --local
 ```
 
-`:remote` variants do the same against the deployed resources. `kv-bulk-upload.ts` deletes every existing `blog:` key before uploading, making the upload a full replacement rather than a merge.
+`:remote` variants do the same against the deployed resources. `kv-bulk-upload.ts` uploads every payload first and only then removes `blog:` keys with nothing behind them, so the result is a full replacement without a moment where a published Post is missing.
 
 ## Data stores
 
@@ -122,7 +122,7 @@ Two layers, and the split between them is deliberate.
 
 **Public HTTP caching, on the three routes whose response is the same for everyone.** `robots.txt` and `sitemap.xml` get an hour, the Resume PDF a day; the PDF is additionally fetched with `cf: { cacheTtl, cacheEverything }` so a warm colo does not re-fetch it from the CDN. The response bodies change only when the seed pipeline runs, so staleness is bounded and the Worker leaves the hot path entirely.
 
-**No public caching on HTML — and this is a constraint, not an omission.** The colour scheme is a class on `<html>`, resolved per request from the `poschuler__color-scheme` cookie. A shared cache would hand one visitor's theme to the next. Making documents cacheable means first taking the theme out of the server-rendered markup (`prefers-color-scheme` only, no cookie), and that trades away the toggle's `system`/explicit distinction. Do not add `Cache-Control: public` to a document route without doing that first.
+**No public caching on HTML — and this is a constraint, not an omission.** The colour scheme is a class on `<html>`, resolved per request from the `__Host-poschuler-color-scheme` cookie. A shared cache would hand one visitor's theme to the next. Making documents cacheable means first taking the theme out of the server-rendered markup (`prefers-color-scheme` only, no cookie), and that trades away the toggle's `system`/explicit distinction. Do not add `Cache-Control: public` to a document route without doing that first.
 
 **KV reads pass `cacheTtl: 3600`**, which is where the blog's latency win actually comes from: the colo answers from its own cache instead of paying a round trip to KV's central store. That is safe regardless of the cookie, because it caches the *body*, not the rendered document.
 
@@ -134,12 +134,14 @@ Two layers, and the split between them is deliberate.
 
 | Value                  | Where it lives            | Used by                                                     |
 | ---------------------- | ------------------------- | ----------------------------------------------------------- |
-| `SESSION_THEME_SECRET` | secret (`wrangler secret`) | signs the `poschuler__color-scheme` cookie                   |
-| `DEPLOYMENT_ENV`       | `vars` in `wrangler.jsonc` | `"production"` gives the theme cookie `Secure` + its domain  |
+| `SESSION_THEME_SECRET` | secret (`wrangler secret`) | signs the `__Host-poschuler-color-scheme` cookie              |
 | `PUBLIC_HOST`          | `vars` in `wrangler.jsonc` | canonical origin in `robots.txt`                             |
+| `DEPLOYMENT_ENV`       | `vars` in `wrangler.jsonc` | declared, no longer read — see below                         |
 | `DB_DEBUG_FLAG`        | `.dev.vars` only           | declared, currently unread                                   |
 
-Non-secret values belong in `wrangler.jsonc`, in git, where a deploy cannot forget them and a new environment needs no manual step. Only the signing secret is invisible to the repository. `.dev.vars` overrides both locally — that is how `DEPLOYMENT_ENV` becomes `"development"` on a dev machine, keeping the cookie off `Secure` and off `.poschuler.com`.
+Non-secret values belong in `wrangler.jsonc`, in git, where a deploy cannot forget them and a new environment needs no manual step. Only the signing secret is invisible to the repository, and `.dev.vars` overrides the rest locally.
+
+**`DEPLOYMENT_ENV` no longer has a reader**, and the way it lost one is worth keeping. It used to decide whether the theme cookie got `Secure` and `Domain=poschuler.com`. While the var was missing in production the cookie was emitted host-only; the day it was finally deployed the same cookie gained a `Domain`, and a browser treats those as two different cookies of the same name. Both get sent, the first one wins, and every returning visitor had their theme frozen while each click wrote the new value somewhere nothing would read it. The cookie is now `__Host-` prefixed, which forbids `Domain` outright — see `app/color-scheme-cookie.ts`. Nothing else consulted the var.
 
 **A secret shadows a var of the same name in production.** If a var in `wrangler.jsonc` appears to have no effect, check `wrangler secret list` before anything else.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -35,7 +35,7 @@ Long-form Post bodies render through `@tailwindcss/typography`, with the `prose`
 
 Theme is a **server-rendered, cookie-backed preference** with no client-side JavaScript at all:
 
-1. `root.tsx`'s loader reads the `poschuler__color-scheme` cookie through `app/color-scheme-cookie.ts` — signed with `SESSION_THEME_SECRET`, parsed by a Zod enum that falls back to `system` on anything unexpected.
+1. `root.tsx`'s loader reads the `__Host-poschuler-color-scheme` cookie through `app/color-scheme-cookie.ts` — signed with `SESSION_THEME_SECRET`, parsed by a Zod enum that falls back to `system` on anything unexpected.
 2. `Layout` puts the resolved value straight onto `<html className={colorScheme}>`. It is in the first byte of the response, so there is nothing to prevent a flash of — no inline script, no provider, no hydration gap.
 3. `ModeToggle` is a `<Form method="POST" action="/set-theme" navigate={false}>` holding one button that advances light → dark → system. The server owns the choice; the button only submits it.
 4. `/set-theme` writes the cookie and **redirects back to the referring page** (same-origin only — `Referer` is attacker-influenceable). Post/Redirect/Get is what makes the toggle survive without JavaScript: returning a body instead leaves a no-JS browser parked on a page reading `null`.
@@ -68,7 +68,7 @@ Two layers, both canonical since the inherited component sets were deleted:
 | Route-local components | Anything used by exactly one route — the first choice          |
 | `app/components/ui/`   | Shared primitives, each a thin Base UI wrapper                 |
 
-**Prefer a route-local component over a shared one.** A component used by exactly one route belongs beside that route, not in `app/components/`. `routes/resume/hero.tsx`, `experience.tsx` and `keyboard-manager.tsx` are the model: they read the parent route's loader data directly via `useLoaderData<typeof loader>()` with a type-only import of the parent's `loader`, so no props need threading. Promote to `app/components/` only on the second consumer.
+**Prefer a route-local component over a shared one.** A component used by exactly one route belongs beside that route, not in `app/components/`. `routes/resume/hero.tsx`, `experience.tsx` and `keyboard-manager.tsx` are the model: each imports the slice of `resume.json` it renders, so no props need threading. When a route does have a loader, the same shape applies with `useLoaderData<typeof loader>()` and a type-only import of the parent's `loader`. Promote to `app/components/` only on the second consumer.
 
 `ui/` holds only what is actually imported — `button`, `icon-button`, `dialog`, `sheet`, `command`, `brand-icons`. Add the one file you need, never a set.
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -135,7 +135,7 @@ done
 echo "==> A failing theme toggle stays confined to its own endpoint"
 curl -s -o /dev/null -X POST "${BASE}/set-theme" \
 	-H "Content-Type: application/x-www-form-urlencoded" \
-	-d "colorScheme=dark" || true
+	-d "color-scheme=dark" || true
 
 for route in / /resume; do
 	status=$(curl -s -o /dev/null -w "%{http_code}" "${BASE}${route}")


### PR DESCRIPTION
The toggle stopped working for every returning visitor the moment `DEPLOYMENT_ENV` reached production. Until then the var was missing, so `isProduction` was false and the cookie went out host-only; with the var in place the same cookie gained `Domain=poschuler.com`.

A browser does not see that as an update. It keeps both, sends both, and whoever parses reads whichever arrives first — the old one. Every click wrote the new value into a cookie nothing would ever read, and the theme sat frozen. Verified against production: the same two cookies swapped in order return `class="system"` or `class="dark"` accordingly.

Dropping `domain` would have worked by relying on browsers ordering same-path cookies oldest-first, which is in RFC 6265 but is the client's behaviour to honour, not something the server can check. The `__Host-` prefix makes the failure impossible instead: browsers reject a cookie carrying it unless it is `Secure`, `Path=/` and has no `Domain`, so a second scope for one name cannot be created — not now, and not by whoever adds a subdomain later.

Renaming also settles the duplicates already out there, since nothing holds the new name. The costs are that everyone's preference resets once, and that `Secure` is now unconditional: `localhost` is a secure origin so dev and preview are unaffected, but a dev server reached over plain http on a LAN address will not persist a theme.

`DEPLOYMENT_ENV` loses its only reader and stays declared, documented as such. The smoke test was posting `colorScheme` where the action reads `color-scheme`; the check was still valid, the field name was not.