### PR TITLE
fix(analytics): stop double-injecting the Web Analytics beacon

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -78,9 +78,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
         {children}
         <ScrollRestoration />
         <Scripts />
-        {/* <!-- Cloudflare Web Analytics --> */}
-        <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "502dbbed6f8448b4ac3841afa524b219"}'></script>
-        {/* <!-- End Cloudflare Web Analytics --> */}
       </body>
     </html>
   );

--- a/workers/security-headers.ts
+++ b/workers/security-headers.ts
@@ -24,6 +24,14 @@ export const STRICT_TRANSPORT_SECURITY = "max-age=31536000; includeSubDomains";
  *
  * `style-src` keeps `'unsafe-inline'` because Base UI positions popups with
  * inline `style` attributes. Scripts do not need it — they carry the nonce.
+ *
+ * The beacon itself is not rendered here: Web Analytics is on automatic
+ * injection (Cloudflare dashboard), so the edge adds the `<script>` — with an
+ * `integrity` attribute we could not set by hand — to the HTML on the way out.
+ * `script-src` still needs the host it loads from. `connect-src` needs only
+ * `'self'`, because automatic injection reports to this domain's own
+ * `/cdn-cgi/rum`, not to `cloudflareinsights.com` the way a manually-embedded
+ * snippet would.
  */
 export function contentSecurityPolicy(nonce: string): string {
   return [
@@ -36,7 +44,7 @@ export function contentSecurityPolicy(nonce: string): string {
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     `script-src 'self' 'nonce-${nonce}' https://static.cloudflareinsights.com`,
-    "connect-src 'self' https://cloudflareinsights.com",
+    "connect-src 'self'",
   ].join("; ");
 }
 


### PR DESCRIPTION
## What

Web Analytics was set to automatic injection on the Cloudflare dashboard, but the beacon snippet was *also* hardcoded in `app/root.tsx` — every page was shipping two copies of the script and reporting RUM twice.

## Why

- Automatic injection adds an `integrity` attribute to the `<script>` tag that a hand-embedded snippet can never carry.
- One less thing to keep hand-synced with whatever Cloudflare's recommended embed looks like this month (the removed snippet was already stale — missing `type="module"`).
- `connect-src` narrows from `'self' https://cloudflareinsights.com` down to just `'self'`, since automatic injection reports to this domain's own `/cdn-cgi/rum` rather than the external endpoint a manual snippet uses.

## Verification

- `pnpm typecheck` — passes
- `pnpm test` — 164/164 passing (31 in `security-headers.test.ts`)
- No dashboard change needed — automatic injection was already the selected option; this PR just stops fighting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)