### PR TITLE
Phase 1b — Field Notes, and a Draft the build refuses to publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,11 @@ ralph-logs/
 
 /handoff/
 
+# `preview:drafts` renders Drafts into these, then applies them to the local
+# D1 and KV. Never the committed fixtures (`seed/d1/seed.sql`,
+# `seed/kv/kv_payloads/`) — that separation is the whole point of the command.
+/preview/
+
 
 
 /evolution-plan/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,13 +39,17 @@ A change to a document Paul has already published, stated in his own words: a da
 _Avoid_: update, changelog, edit, version
 
 **Publication**:
-The act that puts a Content Item in front of readers. It is all or nothing: until it has happened completely, the Content Item is not published, however finished its Markdown is and however long it has been merged. Distinct from Published At, which is a date the Content Item carries, not an event.
+The act that puts a Content Item in front of readers. It is all or nothing: until it has happened completely, the Content Item is not published, however finished its Markdown is and however long it has been merged. Distinct from Published At, which is a date the Content Item carries, not an event. Distinct from Draft, which has not gone through that door at all.
 _Avoid_: release, deploy, ship, seed
+
+**Draft**:
+A document under `app/content/` marked `draft: true` in its front matter. It is checked exactly like a published document — its type against its placement, its Tags against the vocabulary, its Container against the manifest that lists it — and then produces no row, no payload and no address: absent from the Timeline, every index and the sitemap. Not privacy: the repository is public and its history is permanent, so a Draft is out of the site, not out of view. Publishing is deleting one line.
+_Avoid_: unpublished, hidden, private, wip
 
 ### Series
 
 **Container**:
-What a Post belongs to, and what decides the address it is served at. A Post has at most one — today a Series, or none. It is read from the directory the Markdown sits in, never declared in the front matter.
+What a Post belongs to, and what decides the address it is served at. A Post has at most one — a Series, a Project, or none. It is read from the directory the Markdown sits in, never declared in the front matter.
 _Avoid_: parent, group, bucket, collection
 
 **Series**:
@@ -59,6 +63,10 @@ _Avoid_: chapter, module, phase, unit
 **Part**:
 A Post whose Container is a Series. It is an ordinary Post in every other respect — same Timeline, same tags, same body in the same key space — and it does not know where in the Series it sits: the arc is declared once, in the Series manifest.
 _Avoid_: chapter, episode, instalment, entry
+
+**Field Note**:
+A Post whose Container is a Project. It is an ordinary Post in every other respect — same Timeline, same Tags, same body in the same key space — served at `/projects/:project/:note`. Unlike a Part, it carries no arc: a Project's manifest declares which notes it holds and in what order, never a Destination or a reading order, so each note stands on its own and is read on its own.
+_Avoid_: article, entry, case study, page
 
 **Destination**:
 What a Series commits to having built by its end, stated on the landing before any index. **Immutable once the first Part ships.** Everything else about a Series may change — how many Parts, their ordering, the Section boundaries, the pace. This may not: changing it breaks the promise the reader signed up for, and a Series is finished when it reaches its Destination, not when it reaches a number of Parts.
@@ -81,7 +89,7 @@ _Avoid_: version, variant, localization
 ### Professional profile
 
 **Project**:
-Software Paul built and can be judged by, presented as a case study. Like the Resume, it is not a Content Item — no Published At, no place in the Timeline — and it is revised in place rather than published, so its most recent Revision is the only date it carries.
+Software Paul built and can be judged by, presented as a case study. Like the Resume, it is not a Content Item — no Published At, no place in the Timeline — and it is revised in place rather than published, so its most recent Revision is the only date it carries. It may hold Field Notes, declared in its own manifest and indexed at the foot of its landing.
 _Avoid_: work, portfolio item, case, demo
 
 **Project Tier**:

--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ sections:
 
 A **part** is then an ordinary Post one level deeper, `app/content/series/<series>/<part>/<part>.en.md`, with the same front matter any Post has. It declares nothing about the series: its container is the folder it sits in, and its position is wherever the manifest lists it. A section with no parts is planned and a section with parts is in progress, so neither is ever written down. See [ADR 0007](docs/adr/0007-the-manifest-declares-the-arc-a-part-does-not-know-where-it-is.md).
 
+A **Field Note** is the same idea under a Project instead of a Series: an ordinary Post, one level deeper, `app/content/projects/<project>/<note>/<note>.en.md`, served at `/projects/<project>/<note>`. A Project's own front matter declares which notes it holds and in what order, in a flat `notes:` list rather than a Series' sections and destination — a Project accumulates what happened; it does not promise where it is going:
+
+```yaml
+# app/content/projects/chekalo/chekalo.en.md, alongside its existing front matter
+notes:
+  - 'product-matching'
+  - 'alias-flip-vs-reindex-in-place'
+```
+
+Reconciliation is bidirectional, the same check a Series' manifest already runs: a listed note with no file fails the build, a file the manifest does not list fails, and the same note listed twice fails. Recorded on `content` as `project_slug` and `container_order` — the second replacing `section_order`, renamed because that name meant two different things on two tables. See the amendment to [ADR 0007](docs/adr/0007-the-manifest-declares-the-arc-a-part-does-not-know-where-it-is.md) and the comments in `seed/d1/schema.sql`.
+
+Any document under `app/content/` — a loose Post, a Part, a Field Note, a Project or a Series landing — can carry `draft: true`. It is checked exactly as strictly as a published document, and only then produces no row, no payload and no address; publishing is deleting that one line. It is not privacy — the repository is public — it is a state between *absent* and *live* the tree previously had no way to express. `pnpm run preview:drafts` renders every Draft into a gitignored `preview/` directory and applies it to the local D1 and KV, so a Draft reads at its real address without touching a tracked file. See [ADR 0009](docs/adr/0009-a-draft-is-a-document-the-build-validates-and-refuses-to-publish.md).
+
 The filename is the Slug, and it never changes once published — it is the URL. If one has to move anyway, add the old address to `app/lib/redirects.ts`; a test walks that map against the database, so a redirect pointing at a page that no longer exists fails the build. Re-run both seed scripts after adding a file; the KV upload replaces every `blog:` key rather than merging.
 
 ## Commands
@@ -173,6 +186,7 @@ The filename is the Slug, and it never changes once published — it is the URL.
 | `pnpm run d1:reset:local` | Rebuild the local D1 from `schema.sql` (KV is left alone)  |
 | `pnpm run d1:seed:local` | Regenerate `seed.sql` and apply it locally                 |
 | `pnpm run kv:seed:local` | Regenerate KV payloads and upload them locally             |
+| `pnpm run preview:drafts` | Render Drafts into the local D1 and KV, touching no tracked file |
 | `pnpm run verify:stores:local` | Read D1 and KV back and check they match the repo    |
 | `pnpm run check:fixtures` | Regenerate the fixtures and fail if anything changed       |
 | `pnpm run verify:schema:local` | Check the migration chain arrives at `schema.sql`     |

--- a/app/components/project-item.tsx
+++ b/app/components/project-item.tsx
@@ -1,0 +1,42 @@
+import { Briefcase } from "lucide-react";
+import { ListingRow } from "~/components/listing-row";
+import { projectHref } from "~/lib/hrefs";
+import type { ProjectListingRowType } from "~/models/project.server";
+
+/**
+ * One Project in a list — on `/blog`, where a Project with Field Notes is a
+ * single entry among the loose Posts and each Series (Part 10 of
+ * `evolution-plan/14-phase-1b-field-notes.md`).
+ *
+ * The cardinality argument that collapsed a Series into one row is the same
+ * one here: several notes about one Project would make the page describe the
+ * Project rather than describe what this person writes. It shares
+ * `ListingRow` with `ContentItem` and `SeriesItem`, and decides the same two
+ * things `SeriesItem` does: it links to the landing, and it dates itself by
+ * the most recent piece — a Field Note rather than a Part.
+ *
+ * `/blog` is the only page that lists a Project this way, so unlike
+ * `SeriesItem` there is no `showKind` to toggle: the kind always renders.
+ */
+export function ProjectItem({
+  project,
+  headingLevel = "h2",
+}: {
+  project: ProjectListingRowType;
+  headingLevel?: "h2" | "h3";
+}) {
+  return (
+    <ListingRow
+      headingLevel={headingLevel}
+      title={project.title}
+      href={projectHref(project.slug)}
+      icon={Briefcase}
+      meta={
+        <>
+          <time dateTime={project.publishedStringDate}>{project.publishedStringDate}</time>
+          <span>· Project</span>
+        </>
+      }
+    />
+  );
+}

--- a/app/components/project-note-item.tsx
+++ b/app/components/project-note-item.tsx
@@ -1,0 +1,32 @@
+import { PenLine } from "lucide-react";
+import { ListingRow } from "~/components/listing-row";
+import { postHref } from "~/lib/hrefs";
+import type { ProjectNoteRowType } from "~/models/project.server";
+
+/**
+ * One Field Note in a Project's index — the foot of the case study (Part 11 of
+ * `evolution-plan/14-phase-1b-field-notes.md`).
+ *
+ * Shares `ListingRow` with `ContentItem` and `SeriesItem` rather than copying
+ * its bordered block a fourth time. What it adds is the summary: a list of
+ * technical notes does not let a reader choose between them on the title
+ * alone, so it goes on the extra line `ListingRow` already supports.
+ */
+export function ProjectNoteItem({
+  note,
+  projectSlug,
+}: {
+  note: ProjectNoteRowType;
+  projectSlug: string;
+}) {
+  return (
+    <ListingRow
+      title={note.title}
+      href={postHref({ slug: note.slug, seriesSlug: null, projectSlug })}
+      icon={PenLine}
+      meta={<time dateTime={note.publishedStringDate}>{note.publishedStringDate}</time>}
+    >
+      {note.summary && <p className="mt-2 text-pretty text-low text-sm">{note.summary}</p>}
+    </ListingRow>
+  );
+}

--- a/app/lib/hrefs.ts
+++ b/app/lib/hrefs.ts
@@ -1,23 +1,56 @@
 /**
  * Where a Content Item is served from.
  *
- * A Part lives under its Series, a loose Post under `/blog`, and what tells
- * them apart is a column — `content.series_slug` — rather than anything the
- * file declares (ADR 0007). Every list on the site interleaves the two:
- * `/timeline`, the home page's recent writing, and `/blog` itself.
+ * A Part lives under its Series, a Field Note under its Project, a loose Post
+ * under `/blog`, and what tells them apart is a column each — `series_slug`
+ * and `project_slug` — rather than anything the file declares (ADR 0007). Every
+ * list on the site interleaves the three: `/timeline`, the home page's recent
+ * writing, and `/blog` itself.
  *
  * One function rather than a conditional at each call site. `ContentItem`
- * hardcoded `` `/blog/${item.slug}` ``, and that single line is what the column
- * exists to feed — a second copy of the rule is a Part linking to a 404 from
- * whichever list nobody checked.
+ * hardcoded `` `/blog/${item.slug}` ``, and that single line is what the columns
+ * exist to feed — a second copy of the rule is a Part or a Field Note linking
+ * to a 404 from whichever list nobody checked.
  *
  * Pure and client-safe on purpose: the components that build these links are
  * bundled for the browser and cannot reach into `~/models/*.server`.
  */
 
+/**
+ * A Post's Container, derived from the two columns that can each hold one —
+ * `content.series_slug` and `content.project_slug`, never both (`schema.sql`).
+ * Modelled as a discriminated union rather than read as a pair of nullable
+ * strings, so a caller reasons about *which one, if any* rather than checking
+ * two independent nullables that happen to agree.
+ */
+export type Container =
+  | { kind: "series"; slug: string }
+  | { kind: "project"; slug: string }
+  | null;
+
+function containerOf(post: {
+  seriesSlug: string | null;
+  projectSlug: string | null;
+}): Container {
+  if (post.seriesSlug) {
+    return { kind: "series", slug: post.seriesSlug };
+  }
+
+  if (post.projectSlug) {
+    return { kind: "project", slug: post.projectSlug };
+  }
+
+  return null;
+}
+
 /** The Series landing — the page that holds the contract and the whole arc. */
 export function seriesHref(seriesSlug: string): string {
   return `/series/${seriesSlug}`;
+}
+
+/** The Project landing — the case study a Field Note is framed by. */
+export function projectHref(projectSlug: string): string {
+  return `/projects/${projectSlug}`;
 }
 
 /**
@@ -30,7 +63,28 @@ export function tagHref(tag: string): string {
   return `/tags/${tag}`;
 }
 
-/** A Post, wherever it is served: a Part under its Series, or `/blog`. */
-export function postHref(post: { slug: string; seriesSlug: string | null }): string {
-  return post.seriesSlug ? `${seriesHref(post.seriesSlug)}/${post.slug}` : `/blog/${post.slug}`;
+/**
+ * A Post, wherever it is served: a Part under its Series, a Field Note under
+ * its Project, or `/blog`.
+ *
+ * `projectSlug` is optional — most callers only ever hand this a Post inside
+ * a Series' own arc, where a Field Note cannot appear, and repeating `null`
+ * at every one of them would say nothing a default does not already say.
+ */
+export function postHref(post: {
+  slug: string;
+  seriesSlug: string | null;
+  projectSlug?: string | null;
+}): string {
+  const container = containerOf({ seriesSlug: post.seriesSlug, projectSlug: post.projectSlug ?? null });
+
+  if (container?.kind === "series") {
+    return `${seriesHref(container.slug)}/${post.slug}`;
+  }
+
+  if (container?.kind === "project") {
+    return `${projectHref(container.slug)}/${post.slug}`;
+  }
+
+  return `/blog/${post.slug}`;
 }

--- a/app/lib/seo/structured-data.ts
+++ b/app/lib/seo/structured-data.ts
@@ -55,10 +55,12 @@ export type ArticleFacts = {
   dateRevised?: string;
   /** The Series this is a Part of, when it has one. */
   seriesSlug?: string | null;
+  /** The Project this is a Field Note of, when it has one. */
+  projectSlug?: string | null;
 };
 
 /**
- * An article, whether it stands alone or is a Part.
+ * An article, whether it stands alone, is a Part, or is a Field Note.
  *
  * `BlogPosting` rather than `TechArticle`: Google treats them the same for rich
  * results, and `BlogPosting` is what the rest of the ecosystem understands.
@@ -67,6 +69,12 @@ export type ArticleFacts = {
  * article with no Revision has not changed since it was published, which is a
  * fact worth stating — leaving the field out invites the crawler to guess from
  * the response headers, which describe the deploy rather than the writing.
+ *
+ * `seriesSlug` and `projectSlug` are mutually exclusive, the same way the two
+ * columns they are read from are: a Post has one Container or none. Both are
+ * accepted here rather than a single discriminated union because every caller
+ * already has the row shape `content.server.ts` returns, with both columns
+ * present and one of them `null`.
  */
 export function blogPosting({
   path,
@@ -75,6 +83,7 @@ export function blogPosting({
   datePublished,
   dateRevised,
   seriesSlug,
+  projectSlug,
 }: ArticleFacts): JsonLd {
   const url = `${SITE}${path}`;
 
@@ -95,13 +104,31 @@ export function blogPosting({
     // these with the full `Person` on the home page and the Resume.
     author: AUTHOR,
     publisher: AUTHOR,
-    ...(seriesSlug ? { isPartOf: { "@id": seriesId(seriesSlug) } } : {}),
+    ...(seriesSlug
+      ? { isPartOf: { "@id": seriesId(seriesSlug) } }
+      : projectSlug
+        ? { isPartOf: { "@id": projectId(projectSlug) } }
+        : {}),
   };
 }
 
 /** The identifier a Part points at, and the landing declares. */
 export function seriesId(slug: string): string {
   return `${SITE}/series/${slug}#series`;
+}
+
+/**
+ * The identifier a Field Note points at — the Project it is written about.
+ *
+ * The Project landing declares no JSON-LD of its own (out of scope for 1b/7),
+ * so this is not a fragment like `seriesId`'s: a `#project` suffix would be an
+ * `@id` nothing in the site's structured data graph ever defines, which is a
+ * dangling reference for a crawler resolving it. The landing's own URL is a
+ * real resource instead — the page a Field Note's `isPartOf` names is one that
+ * exists, even without a JSON-LD node to greet it there yet.
+ */
+export function projectId(slug: string): string {
+  return `${SITE}/projects/${slug}`;
 }
 
 export type SeriesFacts = {

--- a/app/models/content.server.ts
+++ b/app/models/content.server.ts
@@ -29,7 +29,8 @@ export const CONTENT_COLUMNS = `
       description as "description",
       external_url as "externalUrl",
       source as "source",
-      series_slug as "seriesSlug"`;
+      series_slug as "seriesSlug",
+      project_slug as "projectSlug"`;
 
 type ContentRowBase = {
   idContent: number;
@@ -48,12 +49,14 @@ export type PostRowType = ContentRowBase & {
   externalUrl: null;
   source: null;
   /**
-   * The Container, when the Post is a Part of a Series — and `null` when it is
-   * a loose Post. It is what makes a correct link possible from anywhere:
-   * `/timeline`, the home page and `/blog` all interleave the two, and each
-   * takes a different prefix. `postHref` is the one place that reads it.
+   * The Container, when the Post is a Part of a Series or a Field Note of a
+   * Project — and `null` when it is a loose Post. Never both at once
+   * (`schema.sql`). It is what makes a correct link possible from anywhere:
+   * `/timeline`, the home page and `/blog` all interleave the three, and each
+   * takes a different prefix. `postHref` is the one place that reads them.
    */
   seriesSlug: string | null;
+  projectSlug: string | null;
 };
 
 /** A Bookmark: identified by Slug alone, body stays at the Source. */
@@ -65,6 +68,7 @@ export type BookmarkRowType = ContentRowBase & {
   source: string;
   /** A Bookmark has no Container: nothing about it is Paul's to arrange. */
   seriesSlug: null;
+  projectSlug: null;
 };
 
 /**
@@ -97,16 +101,23 @@ export function findAllPosts(db: D1Database) {
 }
 
 /**
- * Posts that belong to no Series.
+ * Posts that belong to no Container — no Series, no Project.
  *
  * `/blog` lists these plus each Series as a **single entry**, because that page
- * answers *what has this person written* and a series is one thing written, not
- * fifteen. Publishing part nine should update a row there, not lengthen the
- * page. Every other list — the Timeline, the home page — keeps Parts
- * individually, because their question is *what happened lately*.
+ * answers *what has this person written* and a Container is one thing written,
+ * not fifteen. Publishing part nine should update a row there, not lengthen the
+ * page. Every other list — the Timeline, the home page — keeps Parts and Field
+ * Notes individually, because their question is *what happened lately*.
+ *
+ * `/blog` does not list a Project-with-notes as an entry of its own yet — this
+ * query only guarantees a Field Note is not double-counted as a loose Post the
+ * day that lands (1b/6, `evolution-plan/14-phase-1b-field-notes.md` Part 10).
  */
 export function findLoosePosts(db: D1Database) {
-  return findContent<PostRowType>(db, "where type = 'post' and series_slug is null");
+  return findContent<PostRowType>(
+    db,
+    "where type = 'post' and series_slug is null and project_slug is null",
+  );
 }
 
 /**

--- a/app/models/content.server.ts
+++ b/app/models/content.server.ts
@@ -13,17 +13,10 @@ import { dbQuery } from "~/db.server";
  * carrying columns of the same name correlates in a subquery rather than
  * joining in the `from`.
  *
- * **`tags` is deliberately absent, and the column still exists.** The seed still
- * writes it; what stopped is this Worker reading it, and the gap between those
- * two is the whole point. The publish job applies migrations before it deploys
- * the Worker, so a single deploy that dropped the column *and* removed it from
- * this list would leave the **previous** Worker — still asking for it — answering
- * `no such column` on every listing query, for the length of the seed, the build
- * and the deploy. Stopping the read is one deploy; dropping the column is the
- * next. This is the first of the two.
- *
- * Tags are read from `content_tag`; a Post's own chips render from the front
- * matter that travels verbatim in KV. Nothing needs this copy.
+ * **There is no `tags` column to select.** `content` carried a JSON copy of
+ * them until migration 0005 dropped it. Tags are read from `content_tag`, one
+ * row per Tag per Content Item; a Post's own chips render from the front matter
+ * that travels verbatim in KV.
  */
 export const CONTENT_COLUMNS = `
       id_content as "idContent",

--- a/app/models/content.server.ts
+++ b/app/models/content.server.ts
@@ -109,9 +109,10 @@ export function findAllPosts(db: D1Database) {
  * page. Every other list — the Timeline, the home page — keeps Parts and Field
  * Notes individually, because their question is *what happened lately*.
  *
- * `/blog` does not list a Project-with-notes as an entry of its own yet — this
- * query only guarantees a Field Note is not double-counted as a loose Post the
- * day that lands (1b/6, `evolution-plan/14-phase-1b-field-notes.md` Part 10).
+ * `/blog` lists a Project-with-notes as an entry of its own — see
+ * `findProjectsWithNotes` — and this query is what keeps a Field Note from
+ * also being double-counted here as a loose Post (1b/6,
+ * `evolution-plan/14-phase-1b-field-notes.md` Part 10).
  */
 export function findLoosePosts(db: D1Database) {
   return findContent<PostRowType>(

--- a/app/models/project.server.ts
+++ b/app/models/project.server.ts
@@ -10,18 +10,18 @@ import { parseRevisions, type Revision } from "~/lib/revisions";
  * interpolated into a statement. Values still go through `.bind()`.
  */
 const PROJECT_COLUMNS = `
-      id_project as "idProject",
-      slug as "slug",
-      lang as "lang",
-      title as "title",
-      summary as "summary",
-      description as "description",
-      tier as "tier",
-      status as "status",
-      stack as "stack",
-      live_url as "liveUrl",
-      repo_url as "repoUrl",
-      updates as "updates"`;
+      project.id_project as "idProject",
+      project.slug as "slug",
+      project.lang as "lang",
+      project.title as "title",
+      project.summary as "summary",
+      project.description as "description",
+      project.tier as "tier",
+      project.status as "status",
+      project.stack as "stack",
+      project.live_url as "liveUrl",
+      project.repo_url as "repoUrl",
+      project.updates as "updates"`;
 
 /** Weight, never route shape — see ADR 0004's sibling decision in the schema. */
 export type ProjectTier = "flagship" | "supporting" | "experiment";
@@ -64,7 +64,14 @@ function parseStack(stored: string): string[] {
   }
 }
 
-function hydrate(row: StoredProjectRow): ProjectRowType {
+/**
+ * Generic over `T`, the shape `series.server.ts`'s own `hydrate` uses: a row
+ * can carry more than `StoredProjectRow`'s columns — `findProjectsWithNotes`
+ * adds `publishedAt` — and a fixed return type would silently drop it.
+ */
+function hydrate<T extends StoredProjectRow>(
+  row: T,
+): Omit<T, "stack" | "updates"> & { stack: string[]; revisions: Revision[] } {
   const { stack, updates, ...rest } = row;
 
   return { ...rest, stack: parseStack(stack), revisions: parseRevisions(updates) };
@@ -148,4 +155,49 @@ export async function findProjectNotes(
     `,
     [projectSlug, lang],
   );
+}
+
+/**
+ * A Project in a list, dated by the fact `/blog` needs — when it last had
+ * something new. A Project carries no Published At of its own (`project`
+ * holds a case study, not an editorial timestamp), so this is the most recent
+ * of its published Field Notes', the same reasoning `SeriesListingRowType`
+ * already applies to a Series' most recent Part.
+ */
+export type ProjectListingRowType = ProjectRowType & {
+  publishedAt: string;
+  publishedStringDate: string;
+};
+
+/**
+ * Every Project with at least one published Field Note, most recently
+ * advanced first (Part 10 of `evolution-plan/14-phase-1b-field-notes.md`).
+ *
+ * The `join` — not a `left join` — is what excludes a Project with none: unlike
+ * `findAllSeries`, which lists an announced-but-unwritten Series on `/series`
+ * and lets `/blog` filter it out on its own terms, `/blog` is the only reader
+ * of this query and it never wants a Project with nothing written about it.
+ */
+export async function findProjectsWithNotes(db: D1Database, lang = "en") {
+  const rows = await dbQuery<StoredProjectRow & { publishedAt: string }>(
+    db,
+    `select ${PROJECT_COLUMNS},
+        max(c.published_at) as "publishedAt"
+      from project
+      join content c
+        on c.project_slug = project.slug and c.lang = project.lang and c.type = 'post'
+      where project.lang = ?
+      group by project.id_project
+      order by "publishedAt" desc, project.slug asc
+    `,
+    [lang],
+  );
+
+  return rows.map((row): ProjectListingRowType => ({
+    ...hydrate(row),
+    // See `findAllSeries`: `max()` cannot be wrapped by `strftime` and
+    // grouped in the same select without repeating the aggregate, and the
+    // column is already a `YYYY-MM-DD …` string.
+    publishedStringDate: row.publishedAt.slice(0, 10),
+  }));
 }

--- a/app/models/project.server.ts
+++ b/app/models/project.server.ts
@@ -109,3 +109,43 @@ export async function findProjectBySlug(db: D1Database, slug: string, lang = "en
 
   return rows[0] ? hydrate(rows[0]) : null;
 }
+
+/** A Field Note as a Project's index and sibling list need it — no more. */
+export type ProjectNoteRowType = {
+  slug: string;
+  title: string;
+  /** The line a listing shows under the title. `null` is rendered as absent. */
+  summary: string | null;
+  publishedStringDate: string;
+};
+
+/**
+ * The published Field Notes of one Project, in manifest order (Part 8 of
+ * `evolution-plan/14-phase-1b-field-notes.md`) — the order the author chose,
+ * not the order they were written, so the strongest note can lead.
+ *
+ * A Draft holds no `content` row at all, so it is absent from this list by
+ * construction, and reappears in the position it already had the moment its
+ * flag is deleted. Both the landing's index and a note's sibling list read
+ * this same query — the landing renders it whole, a note filters its own
+ * Slug out — so the order is computed once.
+ */
+export async function findProjectNotes(
+  db: D1Database,
+  projectSlug: string,
+  lang = "en",
+): Promise<ProjectNoteRowType[]> {
+  return dbQuery<ProjectNoteRowType>(
+    db,
+    `select
+        slug as "slug",
+        title as "title",
+        description as "summary",
+        strftime('%Y-%m-%d', published_at) as "publishedStringDate"
+      from content
+      where type = 'post' and project_slug = ? and lang = ?
+      order by container_order asc
+    `,
+    [projectSlug, lang],
+  );
+}

--- a/app/models/series.server.ts
+++ b/app/models/series.server.ts
@@ -155,10 +155,11 @@ type ArcJoinRow = {
  *
  * One query rather than one per section, and the same one for all three pages
  * that need it — the landing lists it whole, a Part shows its own section above
- * the article, and previous/next are positions inside it. Ordering is entirely
- * `section_order` on both tables: the position of a section in the manifest's
- * list, and the position of a Part in that section's. Neither number appears in
- * any content file.
+ * the article, and previous/next are positions inside it. Ordering is
+ * `series_section.section_order` — the position of a section in the
+ * manifest's list — and `content.container_order` — the position of a Part in
+ * that section's. Two different columns now, not one name meaning both: see
+ * `schema.sql` and migration 0006. Neither number appears in any content file.
  *
  * The `left join` is what keeps a planned section in the result. It renders on
  * the landing with its summary and no list, and it is what a finished section
@@ -185,7 +186,7 @@ export async function findSeriesArc(
         and c.lang = ss.lang
         and c.series_section = ss.slug
       where ss.series_slug = ? and ss.lang = ?
-      order by ss.section_order asc, c.section_order asc
+      order by ss.section_order asc, c.container_order asc
     `,
     [seriesSlug, lang],
   );

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -15,6 +15,7 @@ export default [
         route("/blog/:blogSlug", "routes/blog-slug/_$blog-slug.tsx"),
         route("/projects", "routes/projects/_projects.tsx"),
         route("/projects/:projectSlug", "routes/project-slug/_$project-slug.tsx"),
+        route("/projects/:projectSlug/:noteSlug", "routes/project-note/_$project-note.tsx"),
 
         // The whole `/series` namespace at once. An index of one entry earns
         // its place by closing the namespace: the alternative was a temporary

--- a/app/routes/blog-slug/_$blog-slug.tsx
+++ b/app/routes/blog-slug/_$blog-slug.tsx
@@ -42,12 +42,12 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
     const { env } = context.get(cloudflareContext);
 
     /**
-     * The row before the body, for one reason: a Part is served under its
-     * Series, and its payload sits under the same `blog:` key as any other Post
-     * — the prefix says what kind of payload it is, not which URL serves it. So
-     * KV alone would answer this URL with a page that also exists at
-     * `/series/…`, and two addresses for one article is a canonical nobody
-     * declared.
+     * The row before the body, for one reason: a Part or a Field Note is
+     * served under its Container, and its payload sits under the same `blog:`
+     * key as any other Post — the prefix says what kind of payload it is, not
+     * which URL serves it. So KV alone would answer this URL with a page that
+     * also exists at `/series/…` or `/projects/…`, and two addresses for one
+     * article is a canonical nobody declared.
      *
      * Not the historical redirects: those are a table of URLs that no longer
      * exist and belong in `app/lib/redirects.ts`, consulted in the Worker. This
@@ -59,7 +59,7 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
         throw new Response("Not Found", { status: 404 });
     }
 
-    if (post.seriesSlug) {
+    if (post.seriesSlug || post.projectSlug) {
         // The query string travels, for the reason `app/lib/redirects.ts`
         // states for the hop before this one: it is what tells the author the
         // redirect is being used at all. The two land on the same page, so

--- a/app/routes/blog/_blog.tsx
+++ b/app/routes/blog/_blog.tsx
@@ -1,38 +1,48 @@
 import { useLoaderData, type MetaFunction } from "react-router";
 import { findLoosePosts, type PostRowType } from "~/models/content.server";
 import { findAllSeries, type SeriesListingRowType } from "~/models/series.server";
+import { findProjectsWithNotes, type ProjectListingRowType } from "~/models/project.server";
 import { ContentItem } from "~/components/content-item";
 import { SeriesItem } from "~/components/series-item";
+import { ProjectItem } from "~/components/project-item";
 import type { Route } from "./+types/_blog";
 import { cloudflareContext } from "~/context";
 import { skipRevalidationOnThemeChange } from "~/lib/revalidation";
 
-/** One row on this page: a loose Post, or a whole Series as a single entry. */
+/** One row on this page: a loose Post, or a whole Container — Series or Project — as a single entry. */
 type BlogEntry =
   | { kind: "post"; post: PostRowType }
-  | { kind: "series"; series: SeriesListingRowType };
+  | { kind: "series"; series: SeriesListingRowType }
+  | { kind: "project"; project: ProjectListingRowType };
 
 /**
- * `/blog` answers *what has this person written*, and a series is one thing
- * written — not fifteen. So it lists **loose Posts plus each Series as a single
- * entry**, linking to its landing. Publishing part nine updates a row here
- * instead of lengthening the page.
+ * `/blog` answers *what has this person written*, and a Container is one thing
+ * written — not fifteen. The rule generalises rather than gaining an exception
+ * for a Project: it lists **a Post with no Container, or a Container that holds
+ * Posts** — loose Posts, plus each Series and each Project with at least one
+ * published Field Note, all as single entries linking to their landing.
+ * Publishing part nine, or a new Field Note, updates a row here instead of
+ * lengthening the page.
  *
- * The alternative — loose Posts only, with series exclusively at `/series` — is
- * cleaner as a model and worse as a site: this page would hold one row while
- * most of the writing lived elsewhere, and `/blog` is the address a reader
- * guesses.
+ * The alternative — loose Posts only, with Series and Projects exclusively at
+ * their own indexes — is cleaner as a model and worse as a site: this page
+ * would hold one row while most of the writing lived elsewhere, and `/blog` is
+ * the address a reader guesses.
  *
- * A Series has no Published At, so it sorts by its **most recent** Part. Its
- * first would sink an actively-written series to the bottom. One with nothing
- * published yet is left out entirely: it is announced, not written, and
- * `/series` is the page that answers what is running.
+ * Neither Container has a Published At of its own, so each sorts by its **most
+ * recent** child. A Series' first Part would sink an actively-written series to
+ * the bottom; the same is true of a Project's first note. A Series with nothing
+ * published yet is left out entirely (`/series` answers what is running); a
+ * Project with no published notes is left out the same way, and `/projects`
+ * answers what exists — `findProjectsWithNotes` excludes it by construction, so
+ * nothing changes on this page until the first note publishes.
  */
 export async function loader({ context }: Route.LoaderArgs) {
   const { env } = context.get(cloudflareContext);
-  const [posts, series] = await Promise.all([
+  const [posts, series, projects] = await Promise.all([
     findLoosePosts(env.POSCHULER_BD),
     findAllSeries(env.POSCHULER_BD),
+    findProjectsWithNotes(env.POSCHULER_BD),
   ]);
 
   const entries: BlogEntry[] = [
@@ -40,10 +50,14 @@ export async function loader({ context }: Route.LoaderArgs) {
     ...series
       .filter((one) => one.publishedAt !== null)
       .map((one): BlogEntry => ({ kind: "series", series: one })),
+    ...projects.map((project): BlogEntry => ({ kind: "project", project })),
   ];
 
-  const dateOf = (entry: BlogEntry) =>
-    entry.kind === "post" ? entry.post.publishedAt : (entry.series.publishedAt ?? "");
+  const dateOf = (entry: BlogEntry) => {
+    if (entry.kind === "post") return entry.post.publishedAt;
+    if (entry.kind === "series") return entry.series.publishedAt ?? "";
+    return entry.project.publishedAt;
+  };
 
   entries.sort((left, right) => dateOf(right).localeCompare(dateOf(left)));
 
@@ -88,17 +102,24 @@ export default function Blog() {
         </div>
       </section>
 
-      {/* `showKind` on the Series rows: this list interleaves two units, so a
-        * row that is a whole series has to say so before the reader clicks it
-        * expecting one article. */}
+      {/* `showKind` on the Series rows, and `ProjectItem` always says its own:
+        * this list interleaves three units, so a row that is a whole
+        * Container has to say so before the reader clicks it expecting one
+        * article. */}
       <section className="mx-auto w-full max-w-measure">
-        {entries.map((entry) =>
-          entry.kind === "post" ? (
-            <ContentItem key={`post:${entry.post.idContent}`} item={entry.post} />
-          ) : (
-            <SeriesItem key={`series:${entry.series.idSeries}`} series={entry.series} showKind />
-          ),
-        )}
+        {entries.map((entry) => {
+          if (entry.kind === "post") {
+            return <ContentItem key={`post:${entry.post.idContent}`} item={entry.post} />;
+          }
+
+          if (entry.kind === "series") {
+            return (
+              <SeriesItem key={`series:${entry.series.idSeries}`} series={entry.series} showKind />
+            );
+          }
+
+          return <ProjectItem key={`project:${entry.project.idProject}`} project={entry.project} />;
+        })}
       </section>
     </main>
   );

--- a/app/routes/project-note/_$project-note.tsx
+++ b/app/routes/project-note/_$project-note.tsx
@@ -3,6 +3,7 @@ import { PostArticle } from "~/components/post-article";
 import { cloudflareContext } from "~/context";
 import { skipRevalidationOnThemeChange } from "~/lib/revalidation";
 import { validateRevisions } from "~/lib/revisions";
+import { blogPosting, breadcrumbList, HOME_CRUMB } from "~/lib/seo/structured-data";
 import { findPostBySlug } from "~/models/content.server";
 import { findProjectBySlug, findProjectNotes } from "~/models/project.server";
 import type { Route } from "./+types/_$project-note";
@@ -99,7 +100,8 @@ export async function loader({ params, context }: Route.LoaderArgs) {
 export const shouldRevalidate = skipRevalidationOnThemeChange;
 
 export function meta({ loaderData }: Route.MetaArgs) {
-  const { title, description, projectSlug, slug } = loaderData;
+  const { title, description, projectSlug, projectTitle, slug, datePublished, revisions } =
+    loaderData;
   const path = `/projects/${projectSlug}/${slug}`;
   const url = `${SITE}${path}`;
 
@@ -115,6 +117,28 @@ export function meta({ loaderData }: Route.MetaArgs) {
     { property: "og:image:alt", content: "Paul Osorio Schuler — Senior Backend Engineer" },
     { property: "og:type", content: "article" },
     { property: "og:url", content: url },
+    {
+      "script:ld+json": blogPosting({
+        path,
+        title,
+        description,
+        datePublished,
+        // Newest first, guaranteed by `validateRevisions`.
+        dateRevised: revisions[0]?.date,
+        projectSlug,
+      }),
+    },
+    // Home › Projects › the Project › this note — four levels, none of them
+    // a claim the site cannot back with a URL (Part 11 of
+    // `evolution-plan/14-phase-1b-field-notes.md`).
+    {
+      "script:ld+json": breadcrumbList([
+        HOME_CRUMB,
+        { name: "Projects", path: "/projects" },
+        { name: projectTitle, path: `/projects/${projectSlug}` },
+        { name: title, path },
+      ]),
+    },
   ];
 }
 

--- a/app/routes/project-note/_$project-note.tsx
+++ b/app/routes/project-note/_$project-note.tsx
@@ -4,9 +4,9 @@ import { cloudflareContext } from "~/context";
 import { skipRevalidationOnThemeChange } from "~/lib/revalidation";
 import { validateRevisions } from "~/lib/revisions";
 import { findPostBySlug } from "~/models/content.server";
-import { findProjectBySlug } from "~/models/project.server";
+import { findProjectBySlug, findProjectNotes } from "~/models/project.server";
 import type { Route } from "./+types/_$project-note";
-import { ProjectBreadcrumb } from "./orientation";
+import { NoteSiblings, ProjectBreadcrumb } from "./orientation";
 
 const SITE = "https://poschuler.com";
 
@@ -46,7 +46,14 @@ export async function loader({ params, context }: Route.LoaderArgs) {
     throw new Response("Not Found", { status: 404 });
   }
 
-  const post = await findPostBySlug(env.POSCHULER_BD, params.noteSlug, project.lang);
+  const [post, notes] = await Promise.all([
+    findPostBySlug(env.POSCHULER_BD, params.noteSlug, project.lang),
+    // The sibling list at the foot (Part 11 of
+    // `evolution-plan/14-phase-1b-field-notes.md`). Read alongside the Post
+    // rather than after it: whether this Slug 404s does not change whose
+    // notes the Project holds.
+    findProjectNotes(env.POSCHULER_BD, project.slug, project.lang),
+  ]);
 
   if (!post || post.projectSlug !== project.slug) {
     throw new Response("Not Found", { status: 404 });
@@ -85,6 +92,7 @@ export async function loader({ params, context }: Route.LoaderArgs) {
     // A malformed list is caught at build time; a page is better off without
     // its revision line than not rendering at all.
     revisions: "revisions" in revisions ? revisions.revisions : [],
+    notes,
   };
 }
 
@@ -112,6 +120,7 @@ export function meta({ loaderData }: Route.MetaArgs) {
 
 export default function ProjectNote() {
   const {
+    slug,
     projectSlug,
     projectTitle,
     title,
@@ -120,6 +129,7 @@ export default function ProjectNote() {
     repository,
     revisions,
     html,
+    notes,
   } = useLoaderData<typeof loader>();
 
   return (
@@ -140,9 +150,17 @@ export default function ProjectNote() {
         html={html}
       />
 
-      {/* No sibling notes and no link back to the Project here — that index
-        * is 1b/5 (`evolution-plan/14-phase-1b-field-notes.md` Part 11). No
-        * previous/next, ever: a Project promises no reading order. */}
+      {/* No previous/next, ever: a Project promises no reading order. What
+        * is offered instead is the other notes and the way back to the
+        * Project (Part 11 of `evolution-plan/14-phase-1b-field-notes.md`) —
+        * `NoteSiblings` renders nothing when there is only one note, and
+        * carries its own layout so nothing renders around it either. */}
+      <NoteSiblings
+        projectSlug={projectSlug}
+        projectTitle={projectTitle}
+        notes={notes}
+        currentSlug={slug}
+      />
     </main>
   );
 }

--- a/app/routes/project-note/_$project-note.tsx
+++ b/app/routes/project-note/_$project-note.tsx
@@ -1,0 +1,148 @@
+import { useLoaderData } from "react-router";
+import { PostArticle } from "~/components/post-article";
+import { cloudflareContext } from "~/context";
+import { skipRevalidationOnThemeChange } from "~/lib/revalidation";
+import { validateRevisions } from "~/lib/revisions";
+import { findPostBySlug } from "~/models/content.server";
+import { findProjectBySlug } from "~/models/project.server";
+import type { Route } from "./+types/_$project-note";
+import { ProjectBreadcrumb } from "./orientation";
+
+const SITE = "https://poschuler.com";
+
+interface NoteAttributes {
+  title: string;
+  description: string;
+  publishedAt: string;
+  /** The subjects, as written. A Field Note's Tags are its own, not the Project's. */
+  tags?: string[];
+  repository?: string;
+  /** Front matter as written; `validateRevisions` is what turns it into a list. */
+  updates?: unknown;
+}
+
+interface NotePayload {
+  attributes: NoteAttributes;
+  html: string;
+}
+
+/**
+ * A Field Note: a Post whose Container is a Project (Part 2 of
+ * `evolution-plan/14-phase-1b-field-notes.md`).
+ *
+ * The body comes from the **`blog:` key space**, the same as any other Post —
+ * the prefix says what kind of payload it is, not which URL serves it. What
+ * this route adds is the frame: the note is only reachable through the
+ * Project the manifest says it belongs to, so a Slug this Project does not
+ * hold is a 404 rather than an article inside somebody else's frame — the
+ * same rule `/series/:seriesSlug/:partSlug` already applies to a Part. A
+ * Draft produces no row at all, so it 404s the same way.
+ */
+export async function loader({ params, context }: Route.LoaderArgs) {
+  const { env } = context.get(cloudflareContext);
+  const project = await findProjectBySlug(env.POSCHULER_BD, params.projectSlug);
+
+  if (!project) {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  const post = await findPostBySlug(env.POSCHULER_BD, params.noteSlug, project.lang);
+
+  if (!post || post.projectSlug !== project.slug) {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  const payload = await env.BLOG_KV.get<NotePayload>(
+    `blog:${params.noteSlug}:${project.lang}`,
+    {
+      type: "json",
+      // A Post body only changes when the seed pipeline runs, so let the colo
+      // answer from its own cache instead of reaching KV's central store.
+      cacheTtl: 3600,
+    },
+  );
+
+  if (!payload) {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  const { attributes, html } = payload;
+  const revisions = validateRevisions(attributes.updates);
+
+  return {
+    slug: params.noteSlug,
+    projectSlug: project.slug,
+    projectTitle: project.title,
+    title: attributes.title,
+    description: attributes.description,
+    tags: attributes.tags ?? [],
+    publishedAt: new Date(attributes.publishedAt).toLocaleDateString(),
+    // The same date, unformatted. What a reader sees is written for their
+    // locale; what a crawler is told has to stay `YYYY-MM-DD`.
+    datePublished: attributes.publishedAt,
+    repository: attributes.repository,
+    html,
+    // A malformed list is caught at build time; a page is better off without
+    // its revision line than not rendering at all.
+    revisions: "revisions" in revisions ? revisions.revisions : [],
+  };
+}
+
+export const shouldRevalidate = skipRevalidationOnThemeChange;
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  const { title, description, projectSlug, slug } = loaderData;
+  const path = `/projects/${projectSlug}/${slug}`;
+  const url = `${SITE}${path}`;
+
+  return [
+    { title: `${title} | Paul Osorio Schuler` },
+    { name: "description", content: description },
+    { tagName: "link", rel: "canonical", href: url },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { property: "og:image", content: `${SITE}/og.png` },
+    { property: "og:image:width", content: "1200" },
+    { property: "og:image:height", content: "630" },
+    { property: "og:image:alt", content: "Paul Osorio Schuler — Senior Backend Engineer" },
+    { property: "og:type", content: "article" },
+    { property: "og:url", content: url },
+  ];
+}
+
+export default function ProjectNote() {
+  const {
+    projectSlug,
+    projectTitle,
+    title,
+    publishedAt,
+    tags,
+    repository,
+    revisions,
+    html,
+  } = useLoaderData<typeof loader>();
+
+  return (
+    <main className="flex-1 gap-4 bg-ui p-4 font-mono md:gap-8 md:p-10">
+      {/* Above the article, exactly as a Part names its Series above its own
+        * title: the reader who arrived from a search engine has to learn what
+        * this is about before reading it, not twenty minutes later. */}
+      <div className="mx-auto w-full max-w-measure pt-8">
+        <ProjectBreadcrumb projectSlug={projectSlug} projectTitle={projectTitle} />
+      </div>
+
+      <PostArticle
+        title={title}
+        publishedAt={publishedAt}
+        tags={tags}
+        repository={repository}
+        revisions={revisions}
+        html={html}
+      />
+
+      {/* No sibling notes and no link back to the Project here — that index
+        * is 1b/5 (`evolution-plan/14-phase-1b-field-notes.md` Part 11). No
+        * previous/next, ever: a Project promises no reading order. */}
+    </main>
+  );
+}

--- a/app/routes/project-note/orientation.tsx
+++ b/app/routes/project-note/orientation.tsx
@@ -1,0 +1,41 @@
+import { Link } from "react-router";
+import { projectHref } from "~/lib/hrefs";
+
+/**
+ * The Project named above a Field Note's title (Part 11 of
+ * `evolution-plan/14-phase-1b-field-notes.md`).
+ *
+ * A reader arriving at a note from a search engine has never seen the home
+ * page and would otherwise start reading without knowing what system this is
+ * about. `SeriesBreadcrumb` in `series-part/orientation.tsx` is the same idea
+ * for a Part; this is its Project sibling, with no section to name because a
+ * Project has none.
+ */
+
+const linkClassName = "transition-colors duration-200 hover:text-default";
+
+export function ProjectBreadcrumb({
+  projectSlug,
+  projectTitle,
+}: {
+  projectSlug: string;
+  projectTitle: string;
+}) {
+  return (
+    <nav aria-label="Breadcrumb" className="text-low text-sm">
+      <ol className="flex flex-wrap items-center gap-x-2">
+        <li>
+          <Link to="/projects" className={linkClassName}>
+            Projects
+          </Link>
+        </li>
+        <li aria-hidden="true">›</li>
+        <li>
+          <Link to={projectHref(projectSlug)} className={linkClassName}>
+            {projectTitle}
+          </Link>
+        </li>
+      </ol>
+    </nav>
+  );
+}

--- a/app/routes/project-note/orientation.tsx
+++ b/app/routes/project-note/orientation.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
-import { projectHref } from "~/lib/hrefs";
+import { postHref, projectHref } from "~/lib/hrefs";
+import type { ProjectNoteRowType } from "~/models/project.server";
 
 /**
  * The Project named above a Field Note's title (Part 11 of
@@ -36,6 +37,65 @@ export function ProjectBreadcrumb({
           </Link>
         </li>
       </ol>
+    </nav>
+  );
+}
+
+/**
+ * The way onward, at the foot of a note (Part 11 of
+ * `evolution-plan/14-phase-1b-field-notes.md`). `SectionIndex` in
+ * `series-part/orientation.tsx` is the same idea for a Part's neighbours
+ * inside its section; this is its Project sibling — a flat list rather than
+ * one grouped by section, because a Project declares no sections.
+ *
+ * `notes` is the Project's whole manifest order; the current note is filtered
+ * out here rather than by the caller, so the "only one note" rule — do not
+ * render at all — and the sibling list stay one computation instead of two
+ * that have to agree.
+ *
+ * **No previous/next.** A Project promises no reading order, so nothing here
+ * claims one.
+ */
+export function NoteSiblings({
+  projectSlug,
+  projectTitle,
+  notes,
+  currentSlug,
+}: {
+  projectSlug: string;
+  projectTitle: string;
+  notes: ProjectNoteRowType[];
+  currentSlug: string;
+}) {
+  const siblings = notes.filter((note) => note.slug !== currentSlug);
+
+  if (siblings.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label={`More Field Notes from ${projectTitle}`}
+      className="mx-auto mt-8 w-full max-w-measure space-y-4 border-default border-t pt-6 pb-8"
+    >
+      <p className="font-semibold text-sm">More Field Notes from {projectTitle}</p>
+
+      <ol className="space-y-1 text-sm">
+        {siblings.map((note) => (
+          <li key={note.slug}>
+            <Link
+              to={postHref({ slug: note.slug, seriesSlug: null, projectSlug })}
+              className={`text-low ${linkClassName}`}
+            >
+              {note.title}
+            </Link>
+          </li>
+        ))}
+      </ol>
+
+      <Link to={projectHref(projectSlug)} className={`block text-low text-sm ${linkClassName}`}>
+        → {projectTitle}, the project
+      </Link>
     </nav>
   );
 }

--- a/app/routes/project-slug/_$project-slug.tsx
+++ b/app/routes/project-slug/_$project-slug.tsx
@@ -1,12 +1,13 @@
 import { useLoaderData } from "react-router";
 import { chip } from "~/components/chip";
 import { LiveLink } from "~/components/live-link";
+import { ProjectNoteItem } from "~/components/project-note-item";
 import { GitHubIcon } from "~/components/ui/brand-icons";
 import { RevisionHistory, RevisionLine } from "~/components/revisions";
 import { cloudflareContext } from "~/context";
 import { skipRevalidationOnThemeChange } from "~/lib/revalidation";
 import { cn } from "~/lib/utils";
-import { findProjectBySlug } from "~/models/project.server";
+import { findProjectBySlug, findProjectNotes } from "~/models/project.server";
 import type { Route } from "./+types/_$project-slug";
 
 const SITE = "https://poschuler.com";
@@ -29,15 +30,18 @@ export async function loader({ params, context }: Route.LoaderArgs) {
     throw new Response("Not Found", { status: 404 });
   }
 
-  const body = await env.BLOG_KV.get<ProjectBodyPayload>(
-    `project:${project.slug}:${project.lang}`,
-    {
+  const [body, notes] = await Promise.all([
+    env.BLOG_KV.get<ProjectBodyPayload>(`project:${project.slug}:${project.lang}`, {
       type: "json",
       // A body only changes when the seed pipeline runs, so let the colo answer
       // from its own cache instead of reaching KV's central store.
       cacheTtl: 3600,
-    },
-  );
+    }),
+    // The index at the foot of the landing (Part 11 of
+    // `evolution-plan/14-phase-1b-field-notes.md`). A Draft holds no row, so
+    // it is already absent here — nothing extra to filter.
+    findProjectNotes(env.POSCHULER_BD, project.slug, project.lang),
+  ]);
 
   if (!body) {
     throw new Response("Not Found", { status: 404 });
@@ -53,6 +57,7 @@ export async function loader({ params, context }: Route.LoaderArgs) {
     repoUrl: project.repoUrl,
     revisions: project.revisions,
     html: body.html,
+    notes,
   };
 }
 
@@ -78,7 +83,7 @@ export function meta({ loaderData }: Route.MetaArgs) {
 }
 
 export default function Project() {
-  const { title, summary, status, liveUrl, repoUrl, revisions, html } =
+  const { slug, title, summary, status, liveUrl, repoUrl, revisions, html, notes } =
     useLoaderData<typeof loader>();
 
   return (
@@ -126,6 +131,20 @@ export default function Project() {
           <RevisionHistory revisions={revisions} />
         </div>
       </article>
+
+      {/* Below the case study, never above it — a hiring manager reading
+        * sixty seconds and leaving must not hit an index first. Absent
+        * entirely rather than an empty heading when there is nothing
+        * published yet (Part 11 of `evolution-plan/14-phase-1b-field-notes.md`). */}
+      {notes.length > 0 && (
+        <section className="mx-auto w-full max-w-measure pb-8">
+          <h2 className="font-semibold text-xl tracking-tight">Field notes</h2>
+
+          {notes.map((note) => (
+            <ProjectNoteItem key={note.slug} note={note} projectSlug={slug} />
+          ))}
+        </section>
+      )}
     </main>
   );
 }

--- a/docs/adr/0006-migrations-for-the-deployed-database-schema-sql-for-the-shape.md
+++ b/docs/adr/0006-migrations-for-the-deployed-database-schema-sql-for-the-shape.md
@@ -31,9 +31,9 @@ Adding a column is safe in that window, because nothing selects a column it does
 1. The publication that stops reading the column ships the code that no longer selects it, and leaves the column in place.
 2. A later publication drops it: the migration, the shared column list, the `INSERT` in the generator, any query in the KV pipeline, and the tests. By then no deployed Worker asks for it, so the same job order is safe.
 
-`content.tags` is the first instance and is currently between the two steps: `content_tag` is what every query reaches for, the chips on a Post render from the front matter that travels in KV, and the column is kept solely because a Worker that is already deployed still selects it. `schema.sql` says so at the column, in the imperative — *do not build on it* — because a column with no reader and no note is indistinguishable from one whose reader has not been written yet.
+`content.tags` is the first instance, and it went through both steps. Phase 2b's publication shipped the Worker and the KV generator no longer selecting the column while `0004` left it in place; the next publication dropped it in `0005`. The cost of getting the order wrong was measured rather than assumed: the two steps were nearly written as one, and the shared column list still naming `tags` is what would have made a single deploy answer `no such column` on every listing page.
 
-**The second step is scheduled, not assumed.** A "we will drop it later" that nobody writes down is how a schema accumulates columns nobody dares remove; this one is tracked as its own piece of work.
+**The second step is scheduled, not assumed.** A "we will drop it later" that nobody writes down is how a schema accumulates columns nobody dares remove; that one was tracked as its own piece of work, which is what got it done.
 
 This is a fact about how this repository changes schemas rather than about any particular column, and it will recur — which is why it amends this ADR instead of becoming one of its own. It does not touch the DDL-never-a-backfill rule above: both steps are `ALTER` and `DROP`, and the reconciling seed still fills whatever shape the migration leaves.
 

--- a/docs/adr/0007-the-manifest-declares-the-arc-a-part-does-not-know-where-it-is.md
+++ b/docs/adr/0007-the-manifest-declares-the-arc-a-part-does-not-know-where-it-is.md
@@ -34,3 +34,18 @@ sections:
 - **Nothing on the site states a total.** "Part 3 of 5" needs a number nobody has — the manifest lists what exists, so nothing knows *Fundamentals* will reach five — and "Part 3 of 3" is available and worse than useless: in a Section still being written it tells the reader they have reached the end, and they have not. What is rendered instead is the list of titles, which cannot lie and grows only when something is published.
 - **`series_section` is a table with rows for Sections that hold nothing.** A planned Section is a row with a title and a summary and no Parts pointing at it, because the arc is the thing being published, not a by-product of the Posts that exist so far.
 - **The manifest is where a mistake is loud.** One file, in the order it renders, is a file a reader of the diff can check. That was the deciding argument over the distributed alternative: not that it is less typing, but that it is reviewable.
+
+## Amendment (Phase 1b): the manifest governs a second Container
+
+A Project declares which Field Notes it holds, and in what order, the same way a Series declares its Parts — a list in its own front matter, reconciled against the folder beneath it by the same two checks: a listed note with no file fails, a file the manifest does not list fails, and the same note listed twice fails. `seed/d1/manifest.ts` is that reconciliation pulled out of `series-sql.ts` into a function both Containers call, rather than copied — a check with two implementations has two chances to drift the day one of them is fixed and the other is not.
+
+What a Project's manifest deliberately does not declare is everything this ADR's opening settled for a Series: no Sections, no Destination, no `complete` status, no contiguity check. The reason is the boundary between the two Containers, and it is worth stating on its own:
+
+> A Series orders because it promised a Destination; a Project accumulates because the problems turn up when they turn up. Both declare what they hold; only one declares where it is going.
+
+A Series' arc is a promise a reader can rely on — Part five costs less if Part two was read first, because the Series said so on its landing before either existed. A Project's notes carry no such claim: each one is self-contained, and the manifest orders them for curation, not for a sequence a reader has to follow. That is also why a Project's manifest carries no status derivation — a Section's *planned* / *in progress* / *complete* states exist because a Section is a stage of an arc moving toward a Destination, and a Project's list of notes is not moving toward anything, only accumulating what happened.
+
+Two supporting consequences:
+
+- **A note listed in the manifest while it is a Draft reconciles normally and renders nothing** — Draft is an orthogonal state (ADR 0009), and the manifest lists a note the day it is declared, not the day it is finished, so a Draft's presence in the list is not a special case the reconciliation has to know about.
+- **The Container-contradiction check (ADR 0009) applies identically to both Containers** — a Project marked as a Draft while one of its notes is published fails the build exactly as a Series landing would, through the same `containerContradictionError`.

--- a/docs/adr/0009-a-draft-is-a-document-the-build-validates-and-refuses-to-publish.md
+++ b/docs/adr/0009-a-draft-is-a-document-the-build-validates-and-refuses-to-publish.md
@@ -1,0 +1,64 @@
+# A Draft is a document the build validates and refuses to publish
+
+`draft: true` in front matter is the whole mechanism. The file lives in `app/content/`, the walker classifies it, and every check a published document faces runs against it — its `type` against its placement (ADR 0004), its Tags against the vocabulary (ADR 0008), the manifest that lists it (ADR 0007) — and only after every one of those passes does the row builder stop: no D1 row, no KV payload, absent from the Timeline, `/blog`, `/tags`, every index and the sitemap. Its URL is a 404.
+
+```
+seed/d1/seed-sql.ts
+
+export function draftError(relativePath: string, draft: unknown): string | null {
+  if (draft === undefined || typeof draft === "boolean") {
+    return null;
+  }
+
+  return `${relativePath} declares draft: ${JSON.stringify(draft)} — draft must be true or false, nothing else`;
+}
+
+export function isDraft(draft: unknown): boolean {
+  return draft === true;
+}
+```
+
+Before this, the repository had two states — *absent* and *live* — and nothing between them. A document a week from finished had nowhere to exist: seeded into D1, rendered into KV, listed beside finished work on the day it was still being written, with nothing in the pipeline able to tell the difference. `draft:` is the third state, and publishing is deleting one line.
+
+This ADR exists because the consequence reads, at first glance, like a violation of ADR 0004. That ADR's rule is that a file under `app/content/` is checked and either becomes a page or fails the build — there is no third outcome. A Draft *is* a third outcome: checked in full, and deliberately producing nothing. Without this record, a future reader finds files that are validated and silent and has to reconstruct why that isn't the defect ADR 0004 exists to prevent.
+
+## What a Draft is not
+
+**Not an exemption from validation.** A Draft passes every check a published document passes — the flag is read last in every generator, after `type`, Tags, manifest listing and revisions have already succeeded or already failed the build. That ordering is the whole point: a problem in a Draft surfaces while it is being written, not on the day it is deleted, one line, to publish.
+
+**Not free to break its Container.** A Container — a Series landing, a Project landing — may be a Draft only while it holds no published content:
+
+```
+seed/d1/manifest.ts
+
+export function containerContradictionError(
+  relativePath: string,
+  files: DraftableFile[],
+): string | null {
+  const published = files.find((file) => !file.draft);
+
+  if (!published) {
+    return null;
+  }
+
+  return `${relativePath} is a draft, but '${published.slug}' is published — a Post cannot be reached through a Container that is not.`;
+}
+```
+
+There is no cascade: a drafted Container does not hide its published children — it refuses to coexist with them. Cascading was considered and rejected, because it reopens the very state this decision closes: a Post marked published that is, in fact, invisible, findable only by opening a different file to learn why.
+
+**Not privacy.** The repository is public and git history is permanent. A Draft is a document that is *out of the site*, not one that is *out of view* — its Markdown is readable in the tree and in every commit that touched it from the first one. That has an operational consequence for anything written under a no-publish policy — the handoff's own is the case in point: no retailer names, no matching thresholds, no volumes, no business metrics — which applies from the first keystroke committed, not edited in afterwards. A threshold written into a Draft and later deleted is not gone; removing it for real means rewriting history and force-pushing.
+
+## Considered Options
+
+- **A file outside `app/content/`** — a `drafts/` directory, or `.gitignore`. Zero code, and the wrong trade: the first time the build looks at the file would be the day it is moved in to publish, so an undeclared Tag or a malformed date surfaces at the worst possible moment instead of while the document is being written. Under `.gitignore` the draft is also unversioned, which is a worse place for a week of writing than the tree it belongs in.
+- **A filename convention**, e.g. `product-matching.en-draft.md`. There is a precedent in this repository, and it is the argument against: a file whose name parses to no Locale is skipped today with a warning nobody reads, and has sat unpublished for months because nothing forces a decision about it — a state the system tolerates instead of modelling. Renaming to publish would also change the Slug, the one identifier this model declares immutable once published.
+- **A `draft: true` flag in front matter, checked as strictly as everything else.** Chosen. Being a Draft is a property of the document, not of where it is filed — which is what makes it checkable, and what keeps the Slug and the file's placement exactly as stable as a published document's.
+
+## Consequences
+
+- **`draft:` is accepted on any document under `app/content/`** — a loose Post, a Part, a Field Note, a Project landing, a Series landing. A Bookmark accepts it too, though the state is not needed for a pointer with nothing half-written about it: permitting one generic condition costs less than a special-cased refusal, and permitting it enables no bad state.
+- **A non-boolean value fails the build.** `draft` is a YAML field, so `draft: 'true'` or `draft: yes` is read as a string, not the boolean it merely looks like — a document silently unpublished, or published, by a typo is worse than one that fails loudly.
+- **Turning a published document back into a Draft un-publishes it for real.** It is simply absent from the rows the generator hands the existing prune, which deletes it — the same mechanism a deleted file already goes through, exercised by a round-trip test for each generator.
+- **A companion command reads a Draft at its real address without touching a tracked file.** `pnpm run preview:drafts` runs the same D1 and KV generators the committed fixtures come from, with two parameters threaded through the same code path rather than a second one: include Drafts, and write to the gitignored `preview/` instead of `seed/`. The result is applied to the disposable local D1 and KV, so there is nothing to revert and nothing that can be committed by accident.
+- **The fixtures are unaffected.** `check:fixtures` regenerates `seed/d1/seed.sql` and `seed/kv/kv_payloads/` with Drafts excluded, exactly as it always has — a Draft in progress never turns the build red, and `preview/` is never the thing that check compares against.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,7 +111,7 @@ The primary key is `(slug, lang, tag)`, plus a partial unique index on `(slug, t
 
 Rows exist for both kinds, and which of them a page lists is a policy of the page: `app/models/tag.server.ts` filters to `type = 'post'` in both queries, so a Tag page and its count on the index describe the same set. Deciding at render is what lets that policy change without a migration.
 
-`content.tags` is the JSON string the front matter used to be seeded into, and it now has **no reader** — the queries use `content_tag`, and the chips on a Post render from the front matter that travels in KV. It is still selected by a Worker that is already deployed, so it is dropped in a later publication than the one that stopped reading it; `schema.sql` says so at the column, and ADR 0006's amendment says why.
+`content` used to carry a JSON `tags` column, seeded from the front matter and read by nothing once `content_tag` arrived. Migration `0005` dropped it, in the publication *after* the one that stopped selecting it — ADR 0006's amendment says why that order is not optional, and this column is its worked example.
 
 The row types encode the same split as the indexes: `ContentRowType` is `PostRowType | BookmarkRowType`, discriminated on `type`, so the columns a kind does not carry are typed `null` rather than `string`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,16 +56,39 @@ a payload sits in decides its key prefix.
 
 Inside a tree, **depth decides what a file is**: the file named after its folder
 *is* that folder, and a subfolder is content living inside it. So
-`series/<series>/<series>.en.md` is the Series and
-`series/<series>/<part>/<part>.en.md` is a Post whose container it is — one
-tree, two types, told apart by the path (ADR 0004, amended). What each tree
-allows to nest is declared in `CONTENT_TREES`; `blog/`, `bookmarks/` and
-`projects/` allow nothing, so a stray subfolder fails rather than acquiring a
-meaning.
+`series/<series>/<series>.en.md` is the Series,
+`series/<series>/<part>/<part>.en.md` is a Post (a Part) whose container it is,
+and `projects/<project>/<note>/<note>.en.md` is a Post (a Field Note) whose
+container is the Project above it — one tree, two types, told apart by the path
+(ADR 0004, amended). What each tree allows to nest is declared in
+`CONTENT_TREES`; `blog/` and `bookmarks/` allow nothing, so a stray subfolder
+there fails rather than acquiring a meaning. `series/` and `projects/` each
+allow one nested type — `post` — which is what makes a Part and a Field Note
+possible in the first place.
 
 The arc itself — which sections a Series has, in what order, and which Parts sit
-in each — is declared once in the Series manifest and nowhere else. A Part's
-front matter says nothing about where it is (ADR 0007).
+in each — is declared once in the Series manifest and nowhere else. A Project's
+manifest is the same idea without an arc: a flat `notes:` list, in the order its
+Field Notes should be indexed, with no Sections, no Destination and no reading
+order to promise (ADR 0007, amended). Neither a Part's nor a Field Note's own
+front matter says anything about where it is.
+
+A Post's Container is recorded on `content` as `series_slug` + `series_section`
+for a Series, or `project_slug` for a Project — never both — plus
+`container_order` for its position in whichever list holds it. `schema.sql`
+carries the reasoning for why that is two specific columns rather than one
+generic pair, and for `container_order` replacing `section_order` under an
+expand-and-contract rename still mid-flight: the previously deployed Worker
+reads the old name until the publication that switches it is confirmed live
+(ADR 0006, amended).
+
+A document under any tree may declare itself a Draft (`draft: true`) rather
+than being placed outside it — checked exactly as strictly as a published one,
+and producing no row and no payload only once every other check has passed
+(ADR 0009). `pnpm run preview:drafts` runs the same generators with Drafts
+included, writing to a gitignored `preview/` directory instead of the tracked
+fixtures, so a Draft can be read at its real address without touching a
+tracked file.
 
 Both generators are Node scripts run from the developer's machine, never in the Worker. That is why `front-matter` and `marked` appear in `dependencies` yet are absent from every runtime import. Sitemap and `robots.txt` rendering is hand-rolled in `app/lib/seo/`, with no third-party SEO dependency.
 
@@ -128,7 +151,7 @@ Read-only at runtime, written only by the seed pipeline.
 
 A Post body is one KV read. Missing key → 404, which is also how an unpublished or misspelled slug behaves.
 
-**The prefix says what kind of payload it is, not which URL serves it.** A Part of a Series is an ordinary Post with a container, so its body sits under `blog:` and is served at `/series/<series>/<part>`. A Series landing takes its own prefix because it is not a Post — a different kind of document, like a Project.
+**The prefix says what kind of payload it is, not which URL serves it.** A Part of a Series, or a Field Note of a Project, is an ordinary Post with a container, so its body sits under `blog:` and is served at `/series/<series>/<part>` or `/projects/<project>/<note>` respectively. A Series or a Project landing takes its own prefix because it is not a Post — a different kind of document.
 
 ## Routes
 
@@ -137,7 +160,7 @@ Routes are declared explicitly in `app/routes.ts` (config-based, not file-system
 | Route            | Store  | Cache-Control  | Notes                                       |
 | ---------------- | ------ | -------------- | ------------------------------------------- |
 | `/`              | D1     | none           | landing page — three newest Posts, plus the flagship Project |
-| `/blog`          | D1     | none           | loose Posts and Series as single entries, merged by date |
+| `/blog`          | D1     | none           | a Post with no Container, or a Container that holds Posts — loose Posts, Series and Projects-with-Field-Notes, one entry each, merged by date |
 | `/bookmarks`     | D1     | none           | `findAllBookmarks`                          |
 | `/timeline`      | D1     | none           | Timeline — `findAll`, Posts and Bookmarks interleaved |
 | `/blog/:blogSlug`| D1 + KV | none          | the row first: a Post with a container 301s to it. Locale hardcoded to `en`; body injected via `dangerouslySetInnerHTML` |
@@ -147,7 +170,8 @@ Routes are declared explicitly in `app/routes.ts` (config-based, not file-system
 | `/tags`          | D1     | none           | `findTagsWithPostCounts` — every Tag some Post carries, by count then alphabetically; indexed, and the only `/tags` URL in the sitemap |
 | `/tags/:tag`     | D1     | none           | `findPostsByTag` — Posts only, newest first; a Tag no Post carries is a 404. `noindex, follow`, and absent from the sitemap |
 | `/projects`      | D1     | none           | `findAllProjects` — flagship first, supporting in a grid |
-| `/projects/:project` | D1 + KV | none      | row frames the page, KV carries the body; Locale hardcoded to `en` |
+| `/projects/:project` | D1 + KV | none      | row frames the page, KV carries the body; Locale hardcoded to `en`; index of its Field Notes at the foot, via `findProjectNotes` |
+| `/projects/:project/:note` | D1 + KV | none | a Field Note — the Project named above the title, sibling notes and a link back at the foot, no previous/next; a Draft, or a note another Project's manifest lists, is a 404 |
 | `/resume`        | none   | none           | no loader — sections import `resume.json` directly      |
 | `/resume.pdf`    | fetch  | 1 day          | proxies `cdn.poschuler.dev`, forces `Content-Disposition: attachment` |
 | `/sitemap.xml`   | KV     | 1 hour         | serves the pre-generated XML verbatim       |

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		"verify:stores:remote": "node ./seed/verify-stores.ts remote",
 		"verify:schema:local": "node ./seed/verify-schema.ts local",
 		"verify:schema:remote": "node ./seed/verify-schema.ts remote",
-		"check:fixtures": "bash ./scripts/check-generated-fixtures.sh"
+		"check:fixtures": "bash ./scripts/check-generated-fixtures.sh",
+		"preview:drafts": "bash ./scripts/preview-drafts.sh"
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.6.0",

--- a/scripts/preview-drafts.sh
+++ b/scripts/preview-drafts.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Renders every Draft into the local D1 and KV, so it can be read at its real
+# address in `dev` before it is published (Part 3 of the field notes).
+#
+# The same generators the committed fixtures come from, run with two extra
+# parameters — `--include-drafts`, and an output directory under `preview/`
+# instead of `seed/d1/` and `seed/kv/`. No tracked file is written: the
+# committed fixtures and `check:fixtures` are untouched, and `preview/` is
+# gitignored, so there is nothing to revert and nothing that can be committed
+# by accident.
+#
+# Returning to the published state needs only the existing local reset and
+# seed commands — this script does not undo itself, because there is nothing
+# of its own to undo.
+
+set -euo pipefail
+
+PREVIEW_DIR="preview"
+
+echo "==> Rebuilding the local D1 from schema.sql"
+pnpm run d1:reset:local >/dev/null
+
+echo "==> Generating seed.sql with Drafts included, into ${PREVIEW_DIR}/d1"
+node ./seed/d1/generate-seed-sql.ts --output-dir "${PREVIEW_DIR}/d1" --include-drafts
+
+echo "==> Applying it to the local D1"
+pnpm exec wrangler d1 execute poschuler --file "${PREVIEW_DIR}/d1/seed.sql" --local >/dev/null
+
+echo "==> Generating KV payloads from the local D1, into ${PREVIEW_DIR}/kv"
+node ./seed/kv/generate-kv-json.ts --output-dir "${PREVIEW_DIR}/kv"
+
+echo "==> Uploading them to the local KV"
+node ./seed/kv/kv-bulk-upload.ts local --output-dir "${PREVIEW_DIR}/kv"
+
+echo
+echo "==> Drafts are live in the local stores — read them in 'pnpm run dev'."
+echo "==> Return to the published state with:"
+echo "        pnpm run d1:reset:local && pnpm run d1:seed:local && pnpm run kv:seed:local"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -28,18 +28,21 @@ BASE="http://localhost:${PORT}"
 # Two lists, because two questions. `/` shows the newest Posts whatever they
 # belong to, so it is asked about all of them. The Post probed by URL has to be
 # one with **no Container**: the `blog:` key space holds every
-# Post body, a Part of a Series included — the prefix says what kind of payload
-# it is, not which URL serves it — but a Part answers 301 at `/blog/<slug>` and
-# `/blog` collapses its whole Series into one row. Both checks below would fail
-# on correct code. Picking the first payload alphabetically works today only
-# because the one loose Post happens to sort first; the next Part published
+# Post body, a Part of a Series or a Field Note of a Project included — the
+# prefix says what kind of payload it is, not which URL serves it — but a Part
+# or a Field Note answers 301 at `/blog/<slug>` and `/blog` collapses its whole
+# Series or Project into one row. Both checks below would fail on correct code.
+# Picking the first payload alphabetically works today only because the one
+# loose Post happens to sort first; the next Part or Field Note published
 # under a slug starting `a`–`h` would break CI and point at nothing.
 #
-# Which slugs are Parts is read from the Series manifests, the same place the
-# generators read the arc from (ADR 0007).
-# Each line is `<series>\t<part>`, so the pair that probes a Part below can be
-# taken whole — a Part read from one manifest and a Series read from another
-# would produce a URL that correctly answers 404.
+# Which slugs are Parts or Field Notes is read from the Series and Project
+# manifests, the same place the generators read the arc and the notes list
+# from (ADR 0007, amended).
+# Each line is `<series-or-project>\t<part-or-note>`, so the pair that probes a
+# Part or a Field Note below can be taken whole — one read from one manifest
+# and its Container read from another would produce a URL that correctly
+# answers 404.
 mapfile -t SERIES_PARTS < <(
 	node --input-type=module -e '
 		import { readdir, readFile } from "node:fs/promises";
@@ -61,13 +64,50 @@ mapfile -t PART_SLUGS < <(
 	if [[ "${#SERIES_PARTS[@]}" -gt 0 ]]; then printf '%s\n' "${SERIES_PARTS[@]}" | cut -f2; fi
 )
 
+# The same pair, for a Project's Field Notes — read from its `notes:` manifest,
+# which lists a Draft note exactly as it lists a published one (1b/2). A Draft
+# produces no `blog:` payload at all, so PROJECT_NOTES is filtered below to the
+# ones that do before it is used for anything — the manifest is not, on its
+# own, proof that a note is live.
+mapfile -t PROJECT_NOTES < <(
+	node --input-type=module -e '
+		import { readdir, readFile } from "node:fs/promises";
+
+		const directory = "seed/kv/kv_payloads/projects";
+
+		for (const file of await readdir(directory).catch(() => [])) {
+			const { attributes } = JSON.parse(await readFile(`${directory}/${file}`, "utf-8"));
+			const project = file.replace(/\.[^.]+\.json$/, "");
+
+			for (const note of attributes.notes ?? []) console.log(`${project}\t${note}`);
+		}
+	'
+)
+
+PUBLISHED_PROJECT_NOTES=()
+
+for pair in "${PROJECT_NOTES[@]}"; do
+	note="${pair#*$'\t'}"
+	[[ -f "seed/kv/kv_payloads/blog/${note}.en.json" ]] && PUBLISHED_PROJECT_NOTES+=("${pair}")
+done
+
+mapfile -t NOTE_SLUGS < <(
+	if [[ "${#PUBLISHED_PROJECT_NOTES[@]}" -gt 0 ]]; then printf '%s\n' "${PUBLISHED_PROJECT_NOTES[@]}" | cut -f2; fi
+)
+
 mapfile -t POST_SLUGS < <(
 	find seed/kv/kv_payloads/blog -name '*.en.json' -exec basename {} .en.json \; | sort
 )
 
 mapfile -t LOOSE_POST_SLUGS < <(
 	printf '%s\n' "${POST_SLUGS[@]}" |
-		{ if [[ "${#PART_SLUGS[@]}" -gt 0 ]]; then grep -vxF "$(printf '%s\n' "${PART_SLUGS[@]}")"; else cat; fi; }
+		{
+			if [[ "${#PART_SLUGS[@]}" -gt 0 || "${#NOTE_SLUGS[@]}" -gt 0 ]]; then
+				grep -vxF "$(printf '%s\n' "${PART_SLUGS[@]}" "${NOTE_SLUGS[@]}")"
+			else
+				cat
+			fi
+		}
 )
 
 if [[ "${#LOOSE_POST_SLUGS[@]}" -eq 0 ]]; then
@@ -126,6 +166,17 @@ if [[ "${#SERIES_PARTS[@]}" -gt 0 ]]; then
 	IFS=$'\t' read -r SERIES_SLUG PART_SLUG <<<"${SERIES_PARTS[0]}"
 
 	ROUTES+=(/series "/series/${SERIES_SLUG}" "/series/${SERIES_SLUG}/${PART_SLUG}")
+fi
+
+# The Project namespace, when a published Field Note exists to probe — mirrors
+# the Series block above. Nothing today publishes one (the first note enters as
+# a Draft, per the phase's own field notes), so this block is a no-op until it
+# does; the moment it does, the route this phase adds is covered without this
+# script needing another edit.
+if [[ "${#PUBLISHED_PROJECT_NOTES[@]}" -gt 0 ]]; then
+	IFS=$'\t' read -r PROJECT_SLUG NOTE_SLUG <<<"${PUBLISHED_PROJECT_NOTES[0]}"
+
+	ROUTES+=(/projects "/projects/${PROJECT_SLUG}" "/projects/${PROJECT_SLUG}/${NOTE_SLUG}")
 fi
 
 if [[ ! -d build/client ]]; then

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -64,6 +64,15 @@ mapfile -t PART_SLUGS < <(
 	if [[ "${#SERIES_PARTS[@]}" -gt 0 ]]; then printf '%s\n' "${SERIES_PARTS[@]}" | cut -f2; fi
 )
 
+# Every Project, from its payload. `/projects` and a Project landing are live
+# routes that read both stores, and they do not wait for a Field Note to exist —
+# so they are discovered here, unconditionally, and not from the notes below.
+# Gating them on a published note is what made this whole namespace a no-op the
+# day the block was written, on a site whose most-linked page is a Project.
+mapfile -t PROJECT_SLUGS < <(
+	find seed/kv/kv_payloads/projects -name '*.en.json' -exec basename {} .en.json \; | sort
+)
+
 # The same pair, for a Project's Field Notes — read from its `notes:` manifest,
 # which lists a Draft note exactly as it lists a published one (1b/2). A Draft
 # produces no `blog:` payload at all, so PROJECT_NOTES is filtered below to the
@@ -168,15 +177,35 @@ if [[ "${#SERIES_PARTS[@]}" -gt 0 ]]; then
 	ROUTES+=(/series "/series/${SERIES_SLUG}" "/series/${SERIES_SLUG}/${PART_SLUG}")
 fi
 
-# The Project namespace, when a published Field Note exists to probe — mirrors
-# the Series block above. Nothing today publishes one (the first note enters as
-# a Draft, per the phase's own field notes), so this block is a no-op until it
-# does; the moment it does, the route this phase adds is covered without this
-# script needing another edit.
-if [[ "${#PUBLISHED_PROJECT_NOTES[@]}" -gt 0 ]]; then
-	IFS=$'\t' read -r PROJECT_SLUG NOTE_SLUG <<<"${PUBLISHED_PROJECT_NOTES[0]}"
+# The Project namespace. The index and a landing are probed always: they read
+# D1 for the row and KV for the body, exactly the pair a missing binding takes
+# down, and neither depends on a Field Note existing.
+#
+# Loud rather than skipped, as the Tag and loose-Post checks above are. This
+# repository ships three Projects and the landing is the address that goes in a
+# CV, so no payload here means the payloads are stale or the Project generator
+# has stopped writing — both worth failing over. A probe that quietly covers
+# nothing is how a gate ends up green while testing nothing.
+if [[ "${#PROJECT_SLUGS[@]}" -eq 0 ]]; then
+	echo "error: no payload under seed/kv/kv_payloads/projects for a Project." >&2
+	echo "       Regenerate the payloads, or edit this check on purpose." >&2
+	exit 1
+fi
 
-	ROUTES+=(/projects "/projects/${PROJECT_SLUG}" "/projects/${PROJECT_SLUG}/${NOTE_SLUG}")
+PROJECT_SLUG="${PROJECT_SLUGS[0]}"
+
+ROUTES+=(/projects "/projects/${PROJECT_SLUG}")
+
+# The note route on top, only when a published Field Note exists to probe.
+# Nothing publishes one today — the first note enters as a Draft — so this is
+# the one part of the namespace that stays conditional, and it covers itself the
+# moment a note goes live, without this script needing another edit. The Project
+# is taken from the pair rather than from PROJECT_SLUG: the note has to be
+# probed under the Project that actually holds it.
+if [[ "${#PUBLISHED_PROJECT_NOTES[@]}" -gt 0 ]]; then
+	IFS=$'\t' read -r NOTE_PROJECT_SLUG NOTE_SLUG <<<"${PUBLISHED_PROJECT_NOTES[0]}"
+
+	ROUTES+=("/projects/${NOTE_PROJECT_SLUG}/${NOTE_SLUG}")
 fi
 
 if [[ ! -d build/client ]]; then
@@ -294,6 +323,12 @@ echo "==> Those pages carry content, not just a status code"
 # own page is that Post.
 expect_mention /blog "${POST_SLUG}"
 expect_mention "/blog/${POST_SLUG}" "${POST_SLUG}"
+
+# The Projects index, for the reason this block exists at all: every entry on it
+# comes from one query, so a 200 survives the query returning nothing. Asked for
+# the Slug of a Project whose payload is on disk, which is the only thing that
+# guarantees the row should be there.
+expect_mention /projects "${PROJECT_SLUG}"
 
 # The Tag page answers 404 for a Tag no Post carries, so a 200 already says the
 # query found something — but not that the row reached the page. The Post the

--- a/seed/d1/content-tree.ts
+++ b/seed/d1/content-tree.ts
@@ -16,6 +16,7 @@
  *     projects/<project>/<project>.en.md                 depth 2
  *     series/<series>/<series>.en.md                     depth 2
  *     series/<series>/<part>/<part>.en.md                depth 3
+ *     projects/<project>/<note>/<note>.en.md              depth 3
  *
  * The file named after its folder *is* that folder; a subfolder is content
  * living inside it. So depth 1 and 2 are the tree's own item, and depth 3 is
@@ -34,15 +35,16 @@ export type ContentType = "post" | "link" | "project" | "series";
  * — if anything — may live nested inside one of its items.
  *
  * `nested: null` means *nothing nests here*. A subfolder under `blog/` fails
- * the build rather than acquiring an invented meaning, and `projects/` says the
- * same for now on purpose: a Field Note needs a `project_slug` on `content` to
- * be linkable, and that column arrives in 1b. Accepting one today would seed a
- * Post with no Container — the silent shape ADR 0004 exists to remove.
+ * the build rather than acquiring an invented meaning. `projects/` used to say
+ * the same, before `project_slug` existed on `content` to make a nested Post
+ * linkable — 1b (`evolution-plan/14-phase-1b-field-notes.md`) is the column's
+ * arrival, and this line is the branch it was reserved for: depth 3 under a
+ * Project is a Field Note, the same depth rule `series/` already generalised.
  */
 export const CONTENT_TREES = {
   blog: { item: "post", nested: null },
   bookmarks: { item: "link", nested: null },
-  projects: { item: "project", nested: null },
+  projects: { item: "project", nested: "post" },
   series: { item: "series", nested: "post" },
 } as const satisfies Record<string, { item: ContentType; nested: ContentType | null }>;
 

--- a/seed/d1/generate-seed-sql.ts
+++ b/seed/d1/generate-seed-sql.ts
@@ -5,7 +5,9 @@ import fm from "front-matter";
 import {
     buildSeedSql,
     contentRowFor,
+    draftError,
     duplicateKeys,
+    isDraft,
     isInvalid,
     isSkipped,
     parseContentFilename,
@@ -87,7 +89,7 @@ async function getMarkdownFilePaths(dir: string): Promise<string[]> {
  * invariants. The only thing they share is the tree that decides which one runs
  * (ADR 0004).
  */
-async function collectProjectRows(): Promise<SeededRow[]> {
+async function collectProjectRows(): Promise<{ rows: SeededRow[]; anyFilesFound: boolean }> {
     const filePaths = await getMarkdownFilePaths(path.join(CONTENT_DIR, "projects"));
     const rows: SeededRow[] = [];
 
@@ -113,7 +115,11 @@ async function collectProjectRows(): Promise<SeededRow[]> {
         console.log(`✅ Generated SQL for project: ${result.key}`);
     }
 
-    return rows;
+    // Distinct from `rows.length > 0`: every Project this walk found may have
+    // declared `draft: true`, and `buildProjectSeedSql` needs to tell that
+    // state apart from "nothing has ever been written" to know whether an
+    // empty `rows` still calls for a prune.
+    return { rows, anyFilesFound: filePaths.length > 0 };
 }
 
 /** One Series folder, read off the disk and split by what each file is. */
@@ -121,8 +127,10 @@ interface SeriesFolder {
     manifests: Array<{ relativePath: string; attributes: SeriesFrontMatter; body: string }>;
     /**
      * The Parts the manifest is reconciled against: only the files carrying a
-     * recognised Locale, because a draft is never seeded and so is never
-     * indexed either.
+     * recognised Locale. A draft filed under the `.en-old.md` convention parses
+     * to no Locale and is excluded here; a draft declared with `draft: true`
+     * has a Locale like any other file and is reconciled the same way, with
+     * `draft: true` set on the entry so `seriesRowsFor` can tell it apart.
      */
     parts: SeriesPartFile[];
     /**
@@ -174,11 +182,24 @@ async function readSeriesFolders(): Promise<Map<string, SeriesFolder>> {
         folder.nested.push({ relativePath, attributes });
 
         if (parsed?.lang) {
+            // Checked here, ahead of `contentRowFor`, and not left to run
+            // there alone: `seriesRowsFor` reads this Part's `draft` below to
+            // decide the Container-contradiction check, before `contentRowFor`
+            // ever sees this file. A malformed value must fail with its own
+            // message rather than being read as "published" and surfacing as a
+            // confusing contradiction against a manifest that never had one.
+            const draftProblem = draftError(relativePath, attributes.draft);
+
+            if (draftProblem) {
+                throw new Error(draftProblem);
+            }
+
             folder.parts.push({
                 slug: parsed.slug,
                 lang: parsed.lang,
                 folder: segments[segments.length - 2],
                 relativePath,
+                draft: isDraft(attributes.draft),
             });
         }
     }
@@ -198,6 +219,14 @@ async function collectSeriesRows(vocabulary: TagVocabulary): Promise<{
     series: SeededRow[];
     sections: SeededRow[];
     content: ContentRow[];
+    /**
+     * Distinct from `series.length > 0`: every Series manifest this walk found
+     * may have declared `draft: true`, and `buildSeriesSeedSql` needs to tell
+     * that state apart from "nothing has ever been written" to know whether an
+     * empty `series` still calls for a prune. A folder existing at all already
+     * guarantees at least one manifest was read — see the throw just below.
+     */
+    anyFilesFound: boolean;
 }> {
     const folders = await readSeriesFolders();
     const series: SeededRow[] = [];
@@ -235,12 +264,21 @@ async function collectSeriesRows(vocabulary: TagVocabulary): Promise<{
                 throw new Error(result.error);
             }
 
-            series.push(result.series);
-            sections.push(...result.sections);
-
+            // The placements are needed either way: a drafted Container's own
+            // Parts must themselves be drafts (the Container-contradiction
+            // check `seriesRowsFor` already ran), and each still has to be
+            // listed and reconciled like any other.
             for (const [slug, placement] of result.parts) {
                 placements.set(`${slug}:${locale}`, placement);
             }
+
+            if (result.draft) {
+                console.warn(`- Skipping: ${manifest.relativePath} is a draft`);
+                continue;
+            }
+
+            series.push(result.series);
+            sections.push(...result.sections);
 
             console.log(`✅ Generated SQL for series: ${result.series.key}`);
         }
@@ -277,7 +315,7 @@ async function collectSeriesRows(vocabulary: TagVocabulary): Promise<{
         }
     }
 
-    return { series, sections, content };
+    return { series, sections, content, anyFilesFound: folders.size > 0 };
 }
 
 /** Reads the disk; the rule itself lives in `content-tree.ts`. */
@@ -397,8 +435,10 @@ async function generateSqlSeed() {
 
     const sqlCommands =
         buildSeedSql(rows) +
-        buildProjectSeedSql(projectRows) +
-        buildSeriesSeedSql(seriesRows.series, seriesRows.sections);
+        buildProjectSeedSql(projectRows.rows, { anyFilesFound: projectRows.anyFilesFound }) +
+        buildSeriesSeedSql(seriesRows.series, seriesRows.sections, {
+            anyFilesFound: seriesRows.anyFilesFound,
+        });
 
     try {
         await fs.mkdir(path.dirname(OUTPUT_SQL_FILE), { recursive: true });

--- a/seed/d1/generate-seed-sql.ts
+++ b/seed/d1/generate-seed-sql.ts
@@ -12,6 +12,7 @@ import {
     isSkipped,
     parseContentFilename,
     type ContentRow,
+    type DraftOptions,
     type FrontMatterAttributes,
     type PartPlacement,
     type SeededRow,
@@ -55,7 +56,7 @@ const CONTENT_TABLE_TREES = ["blog", "bookmarks"] as const;
  */
 
 const CONTENT_DIR = path.join(process.cwd(), "app", "content");
-const OUTPUT_SQL_FILE = path.join(process.cwd(), "seed", "d1", "seed.sql");
+const DEFAULT_OUTPUT_DIR = path.join(process.cwd(), "seed", "d1");
 
 async function getMarkdownFilePaths(dir: string): Promise<string[]> {
     // A tree that does not exist yet is empty, not an error: `projects/` has no
@@ -89,7 +90,9 @@ async function getMarkdownFilePaths(dir: string): Promise<string[]> {
  * invariants. The only thing they share is the tree that decides which one runs
  * (ADR 0004).
  */
-async function collectProjectRows(): Promise<{ rows: SeededRow[]; anyFilesFound: boolean }> {
+async function collectProjectRows(
+    options: DraftOptions,
+): Promise<{ rows: SeededRow[]; anyFilesFound: boolean }> {
     const filePaths = await getMarkdownFilePaths(path.join(CONTENT_DIR, "projects"));
     const rows: SeededRow[] = [];
 
@@ -100,7 +103,7 @@ async function collectProjectRows(): Promise<{ rows: SeededRow[]; anyFilesFound:
         const fileContent = await fs.readFile(filePath, "utf-8");
         const { attributes } = fm<ProjectFrontMatter>(fileContent);
 
-        const result = projectRowFor(relativePath, attributes);
+        const result = projectRowFor(relativePath, attributes, options);
 
         if (isInvalid(result)) {
             throw new Error(result.error);
@@ -215,7 +218,7 @@ async function readSeriesFolders(): Promise<Map<string, SeriesFolder>> {
  * Part sits — see ADR 0007 — so a Part's row cannot be written until its
  * Series has been validated and its lists turned into positions.
  */
-async function collectSeriesRows(vocabulary: TagVocabulary): Promise<{
+async function collectSeriesRows(vocabulary: TagVocabulary, options: DraftOptions): Promise<{
     series: SeededRow[];
     sections: SeededRow[];
     content: ContentRow[];
@@ -272,7 +275,7 @@ async function collectSeriesRows(vocabulary: TagVocabulary): Promise<{
                 placements.set(`${slug}:${locale}`, placement);
             }
 
-            if (result.draft) {
+            if (result.draft && !options.includeDrafts) {
                 console.warn(`- Skipping: ${manifest.relativePath} is a draft`);
                 continue;
             }
@@ -299,7 +302,7 @@ async function collectSeriesRows(vocabulary: TagVocabulary): Promise<{
                 ? placements.get(`${parsed.slug}:${parsed.lang}`)
                 : undefined;
 
-            const result = contentRowFor(file.relativePath, file.attributes, vocabulary, placement);
+            const result = contentRowFor(file.relativePath, file.attributes, vocabulary, placement, options);
 
             if (isInvalid(result)) {
                 throw new Error(result.error);
@@ -364,8 +367,23 @@ async function readTagVocabulary(): Promise<TagVocabulary> {
     return result.vocabulary;
 }
 
-async function generateSqlSeed() {
+/**
+ * Reads `app/content`, writes `<outputDir>/seed.sql`.
+ *
+ * Two parameters, not a second pipeline (Part 3 of the field notes): called
+ * with neither, this is byte-for-byte what it always was. `preview:drafts` is
+ * the only caller that passes either — an output directory outside
+ * `seed/d1/`, so nothing tracked is touched, and `includeDrafts`, so a Draft
+ * is read like a published document instead of being skipped.
+ */
+async function generateSqlSeed({
+    outputDir = DEFAULT_OUTPUT_DIR,
+    includeDrafts = false,
+}: { outputDir?: string; includeDrafts?: boolean } = {}) {
     console.log("🌱 Starting content analysis for SQL generation...");
+
+    const options: DraftOptions = { includeDrafts };
+    const outputSqlFile = path.join(outputDir, "seed.sql");
 
     await assertEveryTreeIsClaimed(CONTENT_DIR);
 
@@ -392,7 +410,7 @@ async function generateSqlSeed() {
         const fileContent = await fs.readFile(filePath, "utf-8");
         const { attributes } = fm<FrontMatterAttributes>(fileContent);
 
-        const result = contentRowFor(relativePath, attributes, vocabulary);
+        const result = contentRowFor(relativePath, attributes, vocabulary, undefined, options);
 
         if (isInvalid(result)) {
             throw new Error(result.error);
@@ -407,8 +425,8 @@ async function generateSqlSeed() {
         console.log(`✅ Generated SQL for ${attributes.type}: ${result.key}`);
     }
 
-    const projectRows = await collectProjectRows();
-    const seriesRows = await collectSeriesRows(vocabulary);
+    const projectRows = await collectProjectRows(options);
+    const seriesRows = await collectSeriesRows(vocabulary, options);
 
     rows.push(...seriesRows.content);
 
@@ -441,20 +459,46 @@ async function generateSqlSeed() {
         });
 
     try {
-        await fs.mkdir(path.dirname(OUTPUT_SQL_FILE), { recursive: true });
-        await fs.writeFile(OUTPUT_SQL_FILE, sqlCommands, "utf-8");
+        await fs.mkdir(path.dirname(outputSqlFile), { recursive: true });
+        await fs.writeFile(outputSqlFile, sqlCommands, "utf-8");
 
-        console.log(`\n\n🌳 SQL generation complete! File saved to: ${OUTPUT_SQL_FILE}`);
+        console.log(`\n\n🌳 SQL generation complete! File saved to: ${outputSqlFile}`);
         console.log("-----------------------------------------------------------------");
         console.log(`>>> Seed with:`);
-        console.log(`pnpm exec wrangler d1 execute poschuler --remote --file ${path.relative(process.cwd(), OUTPUT_SQL_FILE)}`);
+        console.log(`pnpm exec wrangler d1 execute poschuler --remote --file ${path.relative(process.cwd(), outputSqlFile)}`);
 
     } catch (e) {
         console.error("Failed to write SQL file:", e);
     }
 }
 
-generateSqlSeed().catch((e) => {
+/**
+ * `--output-dir <dir>` and `--include-drafts`, both optional. This file sits
+ * outside the coverage target for the same reason the other seed scripts do
+ * — it is disk and subprocess wiring around the tested pure functions above —
+ * so the flags are parsed by hand rather than pulled in a dependency.
+ */
+function parseArgs(argv: string[]): { outputDir?: string; includeDrafts: boolean } {
+    let outputDir: string | undefined;
+    let includeDrafts = false;
+
+    for (let i = 0; i < argv.length; i++) {
+        if (argv[i] === "--output-dir") {
+            outputDir = argv[++i];
+        } else if (argv[i] === "--include-drafts") {
+            includeDrafts = true;
+        }
+    }
+
+    return { outputDir, includeDrafts };
+}
+
+const { outputDir, includeDrafts } = parseArgs(process.argv.slice(2));
+
+generateSqlSeed({
+    outputDir: outputDir ? path.resolve(process.cwd(), outputDir) : undefined,
+    includeDrafts,
+}).catch((e) => {
     console.error("SQL generation failed:");
     console.error(e);
     process.exit(1);

--- a/seed/d1/generate-seed-sql.ts
+++ b/seed/d1/generate-seed-sql.ts
@@ -14,6 +14,7 @@ import {
     type ContentRow,
     type DraftOptions,
     type FrontMatterAttributes,
+    type NotePlacement,
     type PartPlacement,
     type SeededRow,
 } from "./seed-sql.ts";
@@ -25,7 +26,13 @@ import {
     placementOf,
     unclaimedTrees,
 } from "./content-tree.ts";
-import { buildProjectSeedSql, projectRowFor, type ProjectFrontMatter } from "./project-sql.ts";
+import {
+    buildProjectSeedSql,
+    isInvalidProject,
+    projectRowFor,
+    type ProjectFrontMatter,
+    type ProjectNoteFile,
+} from "./project-sql.ts";
 import {
     isMalformedVocabulary,
     tagVocabularyFrom,
@@ -41,9 +48,10 @@ import {
 } from "./series-sql.ts";
 
 /**
- * The trees whose loose files become rows in `content`. Projects have their
- * own table, and `series/` is walked separately below — it holds two kinds of
- * document at once, and which is which is decided by depth.
+ * The trees whose loose files become rows in `content`. `projects/` and
+ * `series/` are both walked separately below — each holds two kinds of
+ * document at once (its own manifest, and content nested inside it), and
+ * which is which is decided by depth.
  */
 const CONTENT_TABLE_TREES = ["blog", "bookmarks"] as const;
 
@@ -83,59 +91,32 @@ async function getMarkdownFilePaths(dir: string): Promise<string[]> {
 }
 
 /**
- * The `projects/` tree, walked by its own rules into its own table.
- *
- * Separate from the loop above rather than a branch inside it: the two produce
- * rows for different tables, from different front matter, with different
- * invariants. The only thing they share is the tree that decides which one runs
- * (ADR 0004).
+ * `SeriesPartFile` and `ProjectNoteFile` are the same shape — Slug, Locale,
+ * folder, path, draft — so one walker can build either: this is what a caller
+ * declaring `files: SeriesPartFile[]` or `files: ProjectNoteFile[]` actually
+ * receives, and TypeScript accepts it structurally without a cast at either
+ * call site.
  */
-async function collectProjectRows(
-    options: DraftOptions,
-): Promise<{ rows: SeededRow[]; anyFilesFound: boolean }> {
-    const filePaths = await getMarkdownFilePaths(path.join(CONTENT_DIR, "projects"));
-    const rows: SeededRow[] = [];
-
-    for (const filePath of filePaths) {
-        const relativePath = path.relative(CONTENT_DIR, filePath);
-        console.log(`Processing ${relativePath}...`);
-
-        const fileContent = await fs.readFile(filePath, "utf-8");
-        const { attributes } = fm<ProjectFrontMatter>(fileContent);
-
-        const result = projectRowFor(relativePath, attributes, options);
-
-        if (isInvalid(result)) {
-            throw new Error(result.error);
-        }
-
-        if (isSkipped(result)) {
-            console.warn(`- Skipping: ${result.reason}`);
-            continue;
-        }
-
-        rows.push(result);
-        console.log(`✅ Generated SQL for project: ${result.key}`);
-    }
-
-    // Distinct from `rows.length > 0`: every Project this walk found may have
-    // declared `draft: true`, and `buildProjectSeedSql` needs to tell that
-    // state apart from "nothing has ever been written" to know whether an
-    // empty `rows` still calls for a prune.
-    return { rows, anyFilesFound: filePaths.length > 0 };
+interface ContainerChildFile {
+    slug: string;
+    lang: string;
+    folder: string;
+    relativePath: string;
+    draft: boolean;
 }
 
-/** One Series folder, read off the disk and split by what each file is. */
-interface SeriesFolder {
-    manifests: Array<{ relativePath: string; attributes: SeriesFrontMatter; body: string }>;
+/** One Container folder — a Series or a Project — split by what each file is. */
+interface ContainerFolder<Manifest> {
+    manifests: Array<{ relativePath: string; attributes: Manifest; body: string }>;
     /**
-     * The Parts the manifest is reconciled against: only the files carrying a
+     * The files the manifest is reconciled against: only the ones carrying a
      * recognised Locale. A draft filed under the `.en-old.md` convention parses
      * to no Locale and is excluded here; a draft declared with `draft: true`
      * has a Locale like any other file and is reconciled the same way, with
-     * `draft: true` set on the entry so `seriesRowsFor` can tell it apart.
+     * `draft: true` set on the entry so the manifest's own row builder can
+     * tell it apart.
      */
-    parts: SeriesPartFile[];
+    files: ContainerChildFile[];
     /**
      * Every file below the folder, drafts included — each one still has to be
      * offered a row, if only to be skipped with a reason.
@@ -144,15 +125,24 @@ interface SeriesFolder {
 }
 
 /**
- * Reads `series/` into one entry per Series folder.
+ * Reads a Container tree — `projects/` or `series/` — into one entry per
+ * folder: the manifest (one per Locale), the content it can be reconciled
+ * against, and every file at all.
  *
- * The manifest and its Parts are told apart by depth, not by a filename
+ * Shared by `readProjectFolders` and `readSeriesFolders` rather than two
+ * walkers reading the same shape — `manifest.ts` was pulled out of
+ * `series-sql.ts` for the same reason on the reconciliation rules, and a
+ * folder walker with two implementations has the same two chances to drift.
+ * The manifest and its content are told apart by depth, not by a filename
  * convention (`content-tree.ts`): the file named after its folder is that
  * folder, and a subfolder is content living inside it.
  */
-async function readSeriesFolders(): Promise<Map<string, SeriesFolder>> {
-    const filePaths = await getMarkdownFilePaths(path.join(CONTENT_DIR, "series"));
-    const folders = new Map<string, SeriesFolder>();
+async function readContainerFolders<Manifest>(
+    tree: "projects" | "series",
+    itemType: "project" | "series",
+): Promise<Map<string, ContainerFolder<Manifest>>> {
+    const filePaths = await getMarkdownFilePaths(path.join(CONTENT_DIR, tree));
+    const folders = new Map<string, ContainerFolder<Manifest>>();
 
     for (const filePath of filePaths) {
         const relativePath = path.relative(CONTENT_DIR, filePath);
@@ -166,14 +156,14 @@ async function readSeriesFolders(): Promise<Map<string, SeriesFolder>> {
 
         const segments = pathSegments(relativePath);
         const folderName = segments[1];
-        const folder = folders.get(folderName) ?? { manifests: [], parts: [], nested: [] };
+        const folder = folders.get(folderName) ?? { manifests: [], files: [], nested: [] };
 
         folders.set(folderName, folder);
 
         const fileContent = await fs.readFile(filePath, "utf-8");
 
-        if (placed.type === "series") {
-            const { attributes, body } = fm<SeriesFrontMatter>(fileContent);
+        if (placed.type === itemType) {
+            const { attributes, body } = fm<Manifest>(fileContent);
 
             folder.manifests.push({ relativePath, attributes, body });
             continue;
@@ -186,18 +176,19 @@ async function readSeriesFolders(): Promise<Map<string, SeriesFolder>> {
 
         if (parsed?.lang) {
             // Checked here, ahead of `contentRowFor`, and not left to run
-            // there alone: `seriesRowsFor` reads this Part's `draft` below to
-            // decide the Container-contradiction check, before `contentRowFor`
-            // ever sees this file. A malformed value must fail with its own
-            // message rather than being read as "published" and surfacing as a
-            // confusing contradiction against a manifest that never had one.
+            // there alone: the manifest's own row builder reads this file's
+            // `draft` below to decide the Container-contradiction check,
+            // before `contentRowFor` ever sees this file. A malformed value
+            // must fail with its own message rather than being read as
+            // "published" and surfacing as a confusing contradiction against a
+            // manifest that never had one.
             const draftProblem = draftError(relativePath, attributes.draft);
 
             if (draftProblem) {
                 throw new Error(draftProblem);
             }
 
-            folder.parts.push({
+            folder.files.push({
                 slug: parsed.slug,
                 lang: parsed.lang,
                 folder: segments[segments.length - 2],
@@ -208,6 +199,128 @@ async function readSeriesFolders(): Promise<Map<string, SeriesFolder>> {
     }
 
     return folders;
+}
+
+/**
+ * Reads `projects/` into one entry per Project folder.
+ */
+function readProjectFolders(): Promise<Map<string, ContainerFolder<ProjectFrontMatter>>> {
+    return readContainerFolders<ProjectFrontMatter>("projects", "project");
+}
+
+/**
+ * The `projects/` tree: the `project` table, plus the Container columns on
+ * every Field Note's row in `content`.
+ *
+ * The manifest is read first because it is the only thing that knows where a
+ * note sits — see ADR 0007 — so a note's row cannot be written until its
+ * Project has been validated and its list turned into positions.
+ */
+async function collectProjectRows(vocabulary: TagVocabulary, options: DraftOptions): Promise<{
+    project: SeededRow[];
+    content: ContentRow[];
+    /**
+     * Distinct from `project.length > 0`: every Project manifest this walk
+     * found may have declared `draft: true`, and `buildProjectSeedSql` needs
+     * to tell that state apart from "nothing has ever been written" to know
+     * whether an empty `project` still calls for a prune. A folder existing at
+     * all already guarantees at least one manifest was read — see the throw
+     * just below.
+     */
+    anyFilesFound: boolean;
+}> {
+    const folders = await readProjectFolders();
+    const project: SeededRow[] = [];
+    const content: ContentRow[] = [];
+
+    for (const [folderName, folder] of folders) {
+        if (folder.manifests.length === 0) {
+            throw new Error(
+                `app/content/projects/${folderName} holds notes and no manifest — nothing would order them or say what the project is for`,
+            );
+        }
+
+        const placements = new Map<string, NotePlacement>();
+        const locales = new Set<string>();
+
+        for (const manifest of folder.manifests) {
+            const parsed = parseContentFilename(basenameOf(manifest.relativePath));
+            const locale = parsed?.lang;
+
+            if (!locale) {
+                throw new Error(`${manifest.relativePath} must have a language in its filename`);
+            }
+
+            locales.add(locale);
+
+            const result = projectRowFor(
+                manifest.relativePath,
+                manifest.attributes,
+                folder.files.filter((note) => note.lang === locale),
+            );
+
+            if (isInvalidProject(result)) {
+                throw new Error(result.error);
+            }
+
+            // The placements are needed either way: a drafted Container's own
+            // notes must themselves be drafts (the Container-contradiction
+            // check `projectRowFor` already ran), and each still has to be
+            // listed and reconciled like any other.
+            for (const [slug, placement] of result.notes) {
+                placements.set(`${slug}:${locale}`, placement);
+            }
+
+            if (result.draft && !options.includeDrafts) {
+                console.warn(`- Skipping: ${manifest.relativePath} is a draft`);
+                continue;
+            }
+
+            project.push(result.project);
+
+            console.log(`✅ Generated SQL for project: ${result.project.key}`);
+        }
+
+        // A note in a Locale its Project does not have would otherwise be
+        // reconciled against nothing and seeded with no Container.
+        for (const note of folder.files) {
+            if (!locales.has(note.lang)) {
+                throw new Error(
+                    `${note.relativePath} is in '${note.lang}' and ${folderName} has no manifest in that Locale`,
+                );
+            }
+        }
+
+        for (const file of folder.nested) {
+            const parsed = parseContentFilename(basenameOf(file.relativePath));
+            const placement = parsed?.lang
+                ? placements.get(`${parsed.slug}:${parsed.lang}`)
+                : undefined;
+
+            const result = contentRowFor(file.relativePath, file.attributes, vocabulary, placement, options);
+
+            if (isInvalid(result)) {
+                throw new Error(result.error);
+            }
+
+            if (isSkipped(result)) {
+                console.warn(`- Skipping: ${result.reason}`);
+                continue;
+            }
+
+            content.push(result);
+            console.log(`✅ Generated SQL for note: ${result.key}`);
+        }
+    }
+
+    return { project, content, anyFilesFound: folders.size > 0 };
+}
+
+/**
+ * Reads `series/` into one entry per Series folder.
+ */
+function readSeriesFolders(): Promise<Map<string, ContainerFolder<SeriesFrontMatter>>> {
+    return readContainerFolders<SeriesFrontMatter>("series", "series");
 }
 
 /**
@@ -260,7 +373,7 @@ async function collectSeriesRows(vocabulary: TagVocabulary, options: DraftOption
                 manifest.relativePath,
                 manifest.attributes,
                 manifest.body,
-                folder.parts.filter((part) => part.lang === locale),
+                folder.files.filter((part) => part.lang === locale),
             );
 
             if (isInvalidSeries(result)) {
@@ -288,7 +401,7 @@ async function collectSeriesRows(vocabulary: TagVocabulary, options: DraftOption
 
         // A Part in a Locale its Series does not have would otherwise be
         // reconciled against nothing and seeded with no Container.
-        for (const part of folder.parts) {
+        for (const part of folder.files) {
             if (!locales.has(part.lang)) {
                 throw new Error(
                     `${part.relativePath} is in '${part.lang}' and ${folderName} has no manifest in that Locale`,
@@ -425,23 +538,24 @@ async function generateSqlSeed({
         console.log(`✅ Generated SQL for ${attributes.type}: ${result.key}`);
     }
 
-    const projectRows = await collectProjectRows(options);
+    const projectRows = await collectProjectRows(vocabulary, options);
     const seriesRows = await collectSeriesRows(vocabulary, options);
 
-    rows.push(...seriesRows.content);
+    rows.push(...projectRows.content, ...seriesRows.content);
 
     // The guard `buildSeedSql` documents but does not make: with no rows its
     // prune matches everything, so an empty walk would empty the live table.
-    // It has to sit after the Series tree is walked, because `blog/` and
-    // `bookmarks/` are no longer the only places a Content Item comes from.
+    // It has to sit after the Project and Series trees are walked, because
+    // `blog/` and `bookmarks/` are no longer the only places a Content Item
+    // comes from.
     if (rows.length === 0) {
         console.log("No content items found in app/content. Exiting.");
         return;
     }
 
     // `content` is unique on (Slug, Locale) site-wide, not per tree, so a Part
-    // competes with every loose Post. Caught here rather than by the database
-    // partway through seeding the deployed store.
+    // or a Field Note competes with every loose Post. Caught here rather than
+    // by the database partway through seeding the deployed store.
     const duplicates = duplicateKeys(rows);
 
     if (duplicates.length > 0) {
@@ -453,7 +567,7 @@ async function generateSqlSeed({
 
     const sqlCommands =
         buildSeedSql(rows) +
-        buildProjectSeedSql(projectRows.rows, { anyFilesFound: projectRows.anyFilesFound }) +
+        buildProjectSeedSql(projectRows.project, { anyFilesFound: projectRows.anyFilesFound }) +
         buildSeriesSeedSql(seriesRows.series, seriesRows.sections, {
             anyFilesFound: seriesRows.anyFilesFound,
         });

--- a/seed/d1/manifest.ts
+++ b/seed/d1/manifest.ts
@@ -1,0 +1,116 @@
+/**
+ * The reconciliation every manifest Container runs against its own tree, and
+ * the Container-contradiction check every Draft Container runs against its
+ * children.
+ *
+ * A Series' manifest and a Project's are different shapes — an arc of
+ * sections against a flat list — but what they check once a slug is in hand is
+ * the same invariant, stated by `series-sql.ts` first: a listed item with no
+ * file fails, a file no manifest lists fails, and the same item listed twice
+ * fails. 1b (Part 8 of `evolution-plan/14-phase-1b-field-notes.md`) needs the
+ * identical check for a Project's notes, so it moved here rather than being
+ * copied — a check with two implementations has two chances to drift the day
+ * one of them is fixed and the other is not.
+ */
+
+/** One slug a manifest lists, and where a duplicate listing would be blamed. */
+export interface ManifestEntry {
+  slug: string;
+  /**
+   * A section's Slug, for a Series — so two sections both listing the same
+   * Part produce *"in both 'a' and 'b'"*. A Project has no sections, so every
+   * entry from one manifest carries the same `where` (the manifest's own
+   * path), which collapses the same branch into a plain *"listed twice"*.
+   */
+  where: string;
+}
+
+/** One file found under a Container's folder, ready to be reconciled. */
+export interface ManifestFile {
+  slug: string;
+  /** The folder it sits in — its own name, per the rule in `content-tree.ts`. */
+  folder: string;
+  relativePath: string;
+}
+
+/**
+ * Manifest and disk must reconcile: every listed item has a file, and every
+ * file under the Container's folder is listed exactly once.
+ *
+ * `noun` names what is being reconciled in the messages this produces — `Part`
+ * or `Field Note` — so a build failure reads like the domain rather than like
+ * a generic "item".
+ */
+export function reconcileManifest(
+  relativePath: string,
+  entries: ManifestEntry[],
+  files: ManifestFile[],
+  noun: string,
+): string | null {
+  const listed = new Map<string, string>();
+
+  for (const entry of entries) {
+    const already = listed.get(entry.slug);
+
+    if (already !== undefined) {
+      return already === entry.where
+        ? `${relativePath} lists the ${noun} '${entry.slug}' twice`
+        : `${relativePath} lists the ${noun} '${entry.slug}' in both '${already}' and '${entry.where}' — a ${noun} is listed in one place`;
+    }
+
+    listed.set(entry.slug, entry.where);
+  }
+
+  const onDisk = new Set(files.map((file) => file.slug));
+
+  for (const slug of listed.keys()) {
+    if (!onDisk.has(slug)) {
+      return `${relativePath} lists the ${noun} '${slug}', which has no file`;
+    }
+  }
+
+  for (const file of files) {
+    // The rule from `content-tree.ts`: the file named after its folder is that
+    // folder. Everything downstream builds the path back from the Slug — the
+    // KV generator reads the body from `<slug>/<slug>.<lang>.md` — so a file
+    // whose filename and folder disagree is a body nothing can find.
+    if (file.folder !== file.slug) {
+      return `${file.relativePath} is not named after its folder '${file.folder}' — nothing could find its body from the Slug`;
+    }
+
+    if (!listed.has(file.slug)) {
+      return `${file.relativePath} is not listed in ${relativePath} — a ${noun} nothing indexes cannot be reached or ordered`;
+    }
+  }
+
+  return null;
+}
+
+/** A file whose own front matter may declare itself a Draft. */
+export interface DraftableFile {
+  slug: string;
+  draft: boolean;
+}
+
+/**
+ * A Container may be a Draft only while it holds no published content (Part 5
+ * of `evolution-plan/14-phase-1b-field-notes.md`). There is no cascade: a
+ * drafted Container does not hide its published children, it refuses to
+ * coexist with them.
+ *
+ * `files` here is only ever the files that would otherwise be reconciled
+ * against this manifest, so an unlisted or misfiled child has already failed
+ * elsewhere by the time this runs.
+ */
+export function containerContradictionError(
+  relativePath: string,
+  files: DraftableFile[],
+): string | null {
+  const published = files.find((file) => !file.draft);
+
+  if (!published) {
+    return null;
+  }
+
+  return `${relativePath} is a draft, but '${published.slug}' is published — a Post cannot be reached through a Container that is not.`;
+}

--- a/seed/d1/migrations/0005_drop_content_tags_column.sql
+++ b/seed/d1/migrations/0005_drop_content_tags_column.sql
@@ -1,0 +1,28 @@
+-- Phase 2b, contract half: the JSON `tags` column on `content` goes.
+--
+-- This is the third step of an expand-and-contract, and the order of the three
+-- is the whole point:
+--
+--   0004  expand   — `content_tag` arrives; the column stays and is still read.
+--   e62bff5        — the Worker and the KV generator stop reading the column;
+--                    it stays, and the seed keeps writing it. Deployed on its
+--                    own, which is what makes this file safe.
+--   0005  contract — the column goes, now that nothing deployed asks for it.
+--
+-- The middle step could not be folded in here. This job applies migrations
+-- before it deploys the Worker (`ci.yml`), so a single deploy that dropped the
+-- column *and* stopped selecting it would leave the previous Worker — still
+-- asking — answering `no such column` on every listing query, through the seed,
+-- the build and the deploy. The Worker serving as this runs is the one from
+-- e62bff5, and it does not select `tags`.
+--
+-- Nothing is lost that is not derived: the Tags of every Content Item live in
+-- `content_tag`, rebuilt from the Markdown on every seed run, and a Post's own
+-- chips render from the front matter that travels verbatim in KV. The Markdown
+-- is the source of truth for both (ADR 0001).
+--
+-- `DROP COLUMN` is available because the column is in no index, no primary key
+-- and no CHECK — SQLite refuses it otherwise. The partial unique indexes on
+-- `content` are over `(slug, lang)` and `(slug)`, and the one CHECK is over
+-- `type` and `lang`, so none of them names this column.
+ALTER TABLE content DROP COLUMN tags;

--- a/seed/d1/migrations/0006_project_container_and_order.sql
+++ b/seed/d1/migrations/0006_project_container_and_order.sql
@@ -1,0 +1,39 @@
+-- Phase 1b, expand half: the Project Container column arrives, and a rename
+-- that cannot be atomic takes its first step.
+--
+-- No `IF NOT EXISTS`, following 0002 through 0005: this runs exactly once
+-- against a database that has neither column, and a statement that quietly
+-- does nothing is the failure mode being designed out.
+
+-- The Container, when it is a Project rather than a Series. Written by the
+-- generator from a Project's `notes:` manifest, same as `series_slug` is
+-- written from a Series' — and never present in front matter, for the same
+-- reason: a Field Note does not know where it is, the manifest says (ADR
+-- 0007). Nothing writes it yet; the walker and generator that read a
+-- Project's manifest are a later ticket. It lands here anyway because this is
+-- the phase's one schema-changing migration — see the field notes.
+ALTER TABLE content ADD COLUMN project_slug TEXT;
+
+-- `container_order` — the position its Container's list gave a Part or a
+-- Field Note. It replaces `section_order`, which meant that on this table and
+-- something else on `series_section` below: a section's position within the
+-- arc, not a Part's position within its section. One name meaning two things
+-- is the collision this rename closes.
+--
+-- The rename is an expand-and-contract, not one statement, and for the reason
+-- `0004` through `0005` already established for `content.tags`: the publish
+-- job applies migrations before it deploys the Worker (ADR 0006's amendment),
+-- so the previously deployed Worker is still asking for `c.section_order`
+-- while this migration runs. Renaming the column out from under it would
+-- answer `no such column` on the Series landing and every Part through the
+-- seed, the build and the deploy.
+--
+-- So `container_order` arrives as a NEW column, `section_order` stays, and
+-- the generator writes both with the same value. The Worker deployed in this
+-- same publication reads `container_order` — the switch happens in the same
+-- deploy as the column arriving, unlike `content.tags`, which needed a
+-- publication of its own for that step (`e62bff5`) because it had not
+-- switched in its expand step. `section_order` is dropped once this
+-- publication is confirmed live, in a migration of its own — the contract
+-- half, gated on that confirmation.
+ALTER TABLE content ADD COLUMN container_order INTEGER;

--- a/seed/d1/project-sql.ts
+++ b/seed/d1/project-sql.ts
@@ -14,6 +14,7 @@ import {
   escapeSql,
   isDraft,
   parseContentFilename,
+  type DraftOptions,
   type FileResult,
   type SeededRow,
 } from "./seed-sql.ts";
@@ -49,10 +50,16 @@ function isOneOf<T extends readonly string[]>(
   return typeof candidate === "string" && (values as readonly string[]).includes(candidate);
 }
 
-/** The `INSERT OR REPLACE` for one Project, or why the build should stop. */
+/**
+ * The `INSERT OR REPLACE` for one Project, or why the build should stop.
+ *
+ * `options.includeDrafts` is `preview:drafts`'s hook (see `DraftOptions` on
+ * `seed-sql.ts`) — every other check still runs unconditionally.
+ */
 export function projectRowFor(
   relativePath: string,
   attributes: ProjectFrontMatter,
+  options?: DraftOptions,
 ): FileResult {
   if (treeOf(relativePath) !== "projects") {
     return { error: `${relativePath} is not in the projects tree` };
@@ -109,8 +116,9 @@ export function projectRowFor(
   }
 
   // The last check, as on a Post: a Draft passes every check a published
-  // Project landing passes, and only then produces nothing.
-  if (isDraft(attributes.draft)) {
+  // Project landing passes, and only then produces nothing, unless the caller
+  // asked for Drafts to be included.
+  if (isDraft(attributes.draft) && !options?.includeDrafts) {
     return { reason: `${relativePath} is a draft` };
   }
 

--- a/seed/d1/project-sql.ts
+++ b/seed/d1/project-sql.ts
@@ -1,21 +1,30 @@
 /**
- * Project front matter → the SQL that seeds the `project` table.
+ * Project front matter → the SQL that seeds the `project` table, and the
+ * position of every Field Note it lists.
  *
  * Pure, like `seed-sql.ts`, and separate from it for the reason a Project has
  * its own table: it is not a Content Item. It has no Published At, never
  * appears in the Timeline, and is revised in place rather than published, so
  * almost none of the rules that govern a Post apply to it.
+ *
+ * The manifest is authorship; D1 is a projection of it (ADR 0001). What the
+ * manifest declares that nothing else could is which notes the Project holds
+ * and in what order — a flat list, not an arc (Part 8 of
+ * `evolution-plan/14-phase-1b-field-notes.md`): a Series orders because it
+ * promised a Destination, a Project accumulates because the problems turn up
+ * when they turn up.
  */
 
 import { validateRevisions } from "../../app/lib/revisions.ts";
 import { basenameOf, treeOf } from "./content-tree.ts";
+import { containerContradictionError, reconcileManifest } from "./manifest.ts";
 import {
   draftError,
   escapeSql,
   isDraft,
   parseContentFilename,
-  type DraftOptions,
-  type FileResult,
+  type InvalidFile,
+  type NotePlacement,
   type SeededRow,
 } from "./seed-sql.ts";
 
@@ -39,8 +48,55 @@ export interface ProjectFrontMatter {
   sortOrder?: number;
   /** `unknown` for the same reason as on a Post: this is a YAML field. */
   updates?: unknown;
+  /**
+   * The Field Notes this Project holds, in the order the index renders them —
+   * curated, not chronological (Part 8). Absent means none yet, which is the
+   * state every Project shipped in before 1b.
+   */
+  notes?: unknown;
   /** `unknown` for the same reason as `updates` — see `draftError`. */
   draft?: unknown;
+}
+
+/** A Markdown file found under a Project folder, already parsed. */
+export interface ProjectNoteFile {
+  /** The Slug, from the filename. */
+  slug: string;
+  lang: string;
+  /** The folder it sits in — its own name, per the rule in `content-tree.ts`. */
+  folder: string;
+  relativePath: string;
+  /**
+   * Whether this note's own front matter declares `draft: true`. Read
+   * leniently here — the definitive check that the value is a boolean at all
+   * happens where the note's own row is built, in `contentRowFor` — because
+   * all this needs is to tell a published note from an unpublished one for
+   * the Container-contradiction check below.
+   */
+  draft: boolean;
+}
+
+export interface ProjectRows {
+  slug: string;
+  lang: string;
+  /** Keyed `slug:lang`. */
+  project: SeededRow;
+  /** Note Slug → where the manifest says it sits. */
+  notes: Map<string, NotePlacement>;
+  /**
+   * Whether this manifest declared itself a Draft. `project` above is still
+   * built when it did — the caller decides whether to seed it — because
+   * `notes` is needed either way: a drafted Container's notes, which must
+   * themselves be Drafts (see the Container-contradiction check), still have
+   * to be listed and reconciled like any other.
+   */
+  draft: boolean;
+}
+
+export type ProjectResult = ProjectRows | InvalidFile;
+
+export function isInvalidProject(result: ProjectResult): result is InvalidFile {
+  return "error" in result;
 }
 
 function isOneOf<T extends readonly string[]>(
@@ -50,17 +106,44 @@ function isOneOf<T extends readonly string[]>(
   return typeof candidate === "string" && (values as readonly string[]).includes(candidate);
 }
 
+function isFilledString(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
 /**
- * The `INSERT OR REPLACE` for one Project, or why the build should stop.
+ * `notes:` must be a list of Slugs when it is declared at all — absent means
+ * none yet, which is a Project's ordinary state before its first note.
+ */
+function notesFrontMatterError(relativePath: string, notes: unknown): string | null {
+  if (notes === undefined) {
+    return null;
+  }
+
+  if (!Array.isArray(notes)) {
+    return `${relativePath} declares notes that is not a list — expected an ordered list of Slugs`;
+  }
+
+  for (const slug of notes) {
+    if (!isFilledString(slug)) {
+      return `${relativePath} lists an empty Field Note`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The rows for one Project manifest, or the reason the build should stop.
  *
- * `options.includeDrafts` is `preview:drafts`'s hook (see `DraftOptions` on
- * `seed-sql.ts`) — every other check still runs unconditionally.
+ * `noteFiles` is every Markdown file under this Project folder that carries
+ * this manifest's Locale and a recognised one at all — the same convention
+ * `seriesRowsFor` reads `partFiles` under.
  */
 export function projectRowFor(
   relativePath: string,
   attributes: ProjectFrontMatter,
-  options?: DraftOptions,
-): FileResult {
+  noteFiles: ProjectNoteFile[],
+): ProjectResult {
   if (treeOf(relativePath) !== "projects") {
     return { error: `${relativePath} is not in the projects tree` };
   }
@@ -115,14 +198,33 @@ export function projectRowFor(
     };
   }
 
-  // The last check, as on a Post: a Draft passes every check a published
-  // Project landing passes, and only then produces nothing, unless the caller
-  // asked for Drafts to be included.
-  if (isDraft(attributes.draft) && !options?.includeDrafts) {
-    return { reason: `${relativePath} is a draft` };
+  const notesProblem = notesFrontMatterError(relativePath, attributes.notes);
+
+  if (notesProblem) {
+    return { error: notesProblem };
   }
 
-  const row: SeededRow = {
+  const noteSlugs = (attributes.notes ?? []) as string[];
+
+  // Every entry from this manifest carries the same `where` — the manifest
+  // has no sections to blame a duplicate on — so a slug listed twice always
+  // reads as "listed twice" rather than "in both 'a' and 'b'".
+  const entries = noteSlugs.map((noteSlug) => ({ slug: noteSlug, where: relativePath }));
+  const reconcile = reconcileManifest(relativePath, entries, noteFiles, "Field Note");
+
+  if (reconcile) {
+    return { error: reconcile };
+  }
+
+  if (isDraft(attributes.draft)) {
+    const contradiction = containerContradictionError(relativePath, noteFiles);
+
+    if (contradiction) {
+      return { error: contradiction };
+    }
+  }
+
+  const project: SeededRow = {
     statement: `
 INSERT OR REPLACE INTO project (slug, lang, title, summary, description, tier, status, stack, live_url, repo_url, sort_order, updates, updated_at)
 VALUES (${escapeSql(slug)}, ${escapeSql(lang)}, ${escapeSql(attributes.title)}, ${escapeSql(attributes.summary.trim())}, ${escapeSql(attributes.description)}, ${escapeSql(attributes.tier)}, ${escapeSql(attributes.status)}, ${escapeSql(JSON.stringify(attributes.stack ?? []))}, ${escapeSql(attributes.liveUrl)}, ${escapeSql(attributes.repoUrl)}, ${attributes.sortOrder ?? 0}, ${escapeSql(JSON.stringify(revisions.revisions))}, CURRENT_TIMESTAMP);
@@ -130,11 +232,17 @@ VALUES (${escapeSql(slug)}, ${escapeSql(lang)}, ${escapeSql(attributes.title)}, 
     key: `${slug}:${lang}`,
   };
 
-  return row;
+  const notes = new Map<string, NotePlacement>();
+
+  noteSlugs.forEach((noteSlug, index) => {
+    notes.set(noteSlug, { projectSlug: slug, order: index });
+  });
+
+  return { slug, lang, project, notes, draft: isDraft(attributes.draft) };
 }
 
 /**
- * Inserts first, prune last, and **nothing at all** when there are no rows —
+ * Inserts first, prune last, and nothing at all when there are no Projects —
  * unless `anyFilesFound` says otherwise.
  *
  * That last part is where this differs from `buildSeedSql`. An empty `project`

--- a/seed/d1/project-sql.ts
+++ b/seed/d1/project-sql.ts
@@ -10,7 +10,9 @@
 import { validateRevisions } from "../../app/lib/revisions.ts";
 import { basenameOf, treeOf } from "./content-tree.ts";
 import {
+  draftError,
   escapeSql,
+  isDraft,
   parseContentFilename,
   type FileResult,
   type SeededRow,
@@ -36,6 +38,8 @@ export interface ProjectFrontMatter {
   sortOrder?: number;
   /** `unknown` for the same reason as on a Post: this is a YAML field. */
   updates?: unknown;
+  /** `unknown` for the same reason as `updates` — see `draftError`. */
+  draft?: unknown;
 }
 
 function isOneOf<T extends readonly string[]>(
@@ -62,11 +66,18 @@ export function projectRowFor(
 
   const { slug, lang } = parsed;
 
-  // No skip branch here, unlike a Post. `.en-old.md` is how a draft Post stays
-  // unpublished; a Project has no drafts — it is one page, revised in place —
-  // so a missing Locale is a mistake rather than an intention.
+  // A Project has no `.en-old.md` convention to hide behind — it is one page,
+  // revised in place, and a filename with no Locale is a mistake rather than
+  // an intention. `draft: true` is the only way one goes unpublished, checked
+  // below, after every other rule has run.
   if (!lang) {
     return { error: `${relativePath} must have a language in its filename` };
+  }
+
+  const draftProblem = draftError(relativePath, attributes.draft);
+
+  if (draftProblem) {
+    return { error: draftProblem };
   }
 
   if (!isOneOf(TIERS, attributes.tier)) {
@@ -97,6 +108,12 @@ export function projectRowFor(
     };
   }
 
+  // The last check, as on a Post: a Draft passes every check a published
+  // Project landing passes, and only then produces nothing.
+  if (isDraft(attributes.draft)) {
+    return { reason: `${relativePath} is a draft` };
+  }
+
   const row: SeededRow = {
     statement: `
 INSERT OR REPLACE INTO project (slug, lang, title, summary, description, tier, status, stack, live_url, repo_url, sort_order, updates, updated_at)
@@ -109,16 +126,25 @@ VALUES (${escapeSql(slug)}, ${escapeSql(lang)}, ${escapeSql(attributes.title)}, 
 }
 
 /**
- * Inserts first, prune last, and **nothing at all** when there are no rows.
+ * Inserts first, prune last, and **nothing at all** when there are no rows —
+ * unless `anyFilesFound` says otherwise.
  *
- * That last part is where this differs from `buildSeedSql`. An empty `content`
- * means the walker found no Markdown, which the caller treats as a reason to
- * stop; an empty `project` is an ordinary state — the table exists before the
- * first Project is written — and a prune built from an empty list would delete
- * every row on the strength of finding nothing.
+ * That last part is where this differs from `buildSeedSql`. An empty `project`
+ * with nothing found on disk is an ordinary state — the table exists before
+ * the first Project is written — and a prune built from that silence would
+ * delete every row on the strength of finding nothing.
+ *
+ * But zero rows is no longer only that state: every Project this walk found
+ * may have declared `draft: true`, in which case something *was* found and a
+ * previously published Project must still be pruned. The caller is the only
+ * one who knows which case this is — `rows.length` alone cannot say — so it
+ * passes `anyFilesFound` for the files it walked, drafts included.
  */
-export function buildProjectSeedSql(rows: SeededRow[]): string {
-  if (rows.length === 0) {
+export function buildProjectSeedSql(
+  rows: SeededRow[],
+  { anyFilesFound = false }: { anyFilesFound?: boolean } = {},
+): string {
+  if (rows.length === 0 && !anyFilesFound) {
     return "";
   }
 

--- a/seed/d1/schema.sql
+++ b/seed/d1/schema.sql
@@ -17,15 +17,10 @@ CREATE TABLE content (
     external_url TEXT,
     source TEXT,
 
-    -- The Tags as they were written, a JSON array, and nothing renders it:
-    -- `content_tag` below is what a query reaches for, and the chips on a Post
-    -- render from the front matter that travels verbatim in KV. It is kept
-    -- because the Worker's shared column list and the KV generator still select
-    -- it, and migrations run before the Worker — dropping it here would leave
-    -- the previous Worker asking for a column that is gone, which is 500s on
-    -- every listing page. The column and both selections go together, in a
-    -- later deploy. Do not build on it.
-    tags TEXT,
+    -- No Tags here, deliberately. `content_tag` below holds one row per Tag per
+    -- Content Item and is what a query reaches for; a Post's own chips render
+    -- from the front matter that travels verbatim in KV. A JSON copy on this
+    -- row existed until 0005 and had no reader by the end.
 
     -- The Container, when this Post has one. All three are written by the
     -- generator from the Series manifest and never appear in front matter: a

--- a/seed/d1/schema.sql
+++ b/seed/d1/schema.sql
@@ -25,8 +25,7 @@ CREATE TABLE content (
     -- The Container, when this Post has one — a Series or a Project, never
     -- both. Written by the generator from the Series or Project manifest and
     -- never appears in front matter: a Part or a Field Note does not know
-    -- where it is, the manifest says (ADR 0007). `project_slug` arrives with
-    -- this column; nothing writes it yet, that is a later ticket.
+    -- where it is, the manifest says (ADR 0007).
     --
     -- Two Container slugs, not one generic pair: `series_section` does not
     -- generalise — a Field Note has no section and never will — so a

--- a/seed/d1/schema.sql
+++ b/seed/d1/schema.sql
@@ -22,17 +22,41 @@ CREATE TABLE content (
     -- from the front matter that travels verbatim in KV. A JSON copy on this
     -- row existed until 0005 and had no reader by the end.
 
-    -- The Container, when this Post has one. All three are written by the
-    -- generator from the Series manifest and never appear in front matter: a
-    -- Part does not know where it is, the manifest says (ADR 0007).
+    -- The Container, when this Post has one — a Series or a Project, never
+    -- both. Written by the generator from the Series or Project manifest and
+    -- never appears in front matter: a Part or a Field Note does not know
+    -- where it is, the manifest says (ADR 0007). `project_slug` arrives with
+    -- this column; nothing writes it yet, that is a later ticket.
     --
-    -- `series_slug` is what makes a correct link possible from anywhere. Any
-    -- listing that renders a Post needs it to build the href — the Timeline
-    -- interleaves Bookmarks, loose Posts and Parts, and each takes a different
-    -- prefix.
+    -- Two Container slugs, not one generic pair: `series_section` does not
+    -- generalise — a Field Note has no section and never will — so a
+    -- `container_kind` + `container_slug` pair would leave it stranded beside
+    -- a column with nothing to say. `series_slug` and `project_slug` are what
+    -- make a correct link possible from anywhere: the Timeline interleaves
+    -- Bookmarks, loose Posts, Parts and Field Notes, and each takes a
+    -- different prefix. The invariant that at most one is set is enforced in
+    -- TypeScript, as a discriminated union over these columns, not by a
+    -- `CHECK` — SQLite cannot add one without recreating the table.
     series_slug TEXT,
-    series_section TEXT,   -- the section's slug, within that Series
-    section_order INTEGER, -- the Part's position in its section's list
+    series_section TEXT, -- the section's slug, within that Series
+    project_slug TEXT,   -- the Project, when the Container is one
+
+    -- The Container's position in its list: a Part's position within its
+    -- section, or a Field Note's position within its Project's `notes:`. Every
+    -- query orders by this column now.
+    container_order INTEGER,
+
+    -- The same fact, under the name this column used to carry alone —
+    -- `section_order`, which also names a column on `series_section` below
+    -- with a different meaning: that table's is a section's position within
+    -- the arc, not a Part's position within its section. Migration 0006 could
+    -- not rename it in place: this job applies migrations before it deploys
+    -- the Worker, and the previously deployed Worker is still asking for
+    -- `c.section_order` while that migration runs. So it stays, written by the
+    -- generator with the same value as `container_order` and read by nothing
+    -- here, until migration 0007 drops it — safe once this publication is
+    -- live, per ADR 0006's amendment.
+    section_order INTEGER,
 
     -- What the author says changed, newest first, as a JSON array of
     -- { date, note }. Distinct from `updated_at` below, which is when the

--- a/seed/d1/seed-sql.ts
+++ b/seed/d1/seed-sql.ts
@@ -27,6 +27,11 @@ export interface FrontMatterAttributes {
    * what turns it into a list.
    */
   updates?: unknown;
+  /**
+   * `unknown` for the same reason as `updates`. `draftError` is what turns it
+   * into a boolean or a build failure.
+   */
+  draft?: unknown;
 }
 
 /**
@@ -129,6 +134,30 @@ export function parseContentFilename(
 }
 
 /**
+ * `draft: true` in front matter (see `evolution-plan/14-phase-1b-field-notes.md`
+ * Part 3) is the whole mechanism: a file declares itself a Draft, is read,
+ * classified and checked exactly like a published one, and only at the very
+ * end does it produce nothing.
+ *
+ * JavaScript's own truthiness is not trusted for the flag. `draft` is a YAML
+ * field, so `draft: 'true'` or `draft: yes` must fail the build rather than
+ * being read as the boolean it merely looks like — a document silently
+ * unpublished by a typo is worse than one that fails loudly.
+ */
+export function draftError(relativePath: string, draft: unknown): string | null {
+  if (draft === undefined || typeof draft === "boolean") {
+    return null;
+  }
+
+  return `${relativePath} declares draft: ${JSON.stringify(draft)} — draft must be true or false, nothing else`;
+}
+
+/** Whether a document is a Draft. `true` and nothing else counts — see `draftError`. */
+export function isDraft(draft: unknown): boolean {
+  return draft === true;
+}
+
+/**
  * One `content_tag` row per Tag the file carries.
  *
  * Written for Posts and Bookmarks alike, and for a Part exactly as for a loose
@@ -207,16 +236,26 @@ export function contentRowFor(
   const publishedAt = escapeSql(attributes.publishedAt);
   const title = escapeSql(attributes.title);
 
+  // Checked once, ahead of the branch: both a Post and a Bookmark can declare
+  // themselves a Draft, and a bad value is a mistake regardless of which one
+  // this file is.
+  const draftProblem = draftError(relativePath, attributes.draft);
+
+  if (draftProblem) {
+    return { error: draftProblem };
+  }
+
   if (attributes.type === "post") {
     if (!lang) {
       return { reason: `post ${filename} must have a language in its filename` };
     }
 
-    // Also after the Locale check, and for the same reason: a draft is never
-    // seeded, so it is never measured against the vocabulary either. That is
-    // what leaves `project-setup.en-old.md` holding the pre-vocabulary
-    // spellings without stopping the build — and what turns renaming it into a
-    // build failure, which is the honest outcome.
+    // Also after the Locale check, and for the same reason: a draft with no
+    // recognised Locale — the `.en-old.md` convention — is never seeded, so it
+    // is never measured against the vocabulary either. That is what leaves
+    // `project-setup.en-old.md` holding the pre-vocabulary spellings without
+    // stopping the build — and what turns renaming it into a build failure,
+    // which is the honest outcome.
     const badTag = tagError(relativePath, attributes.tags, vocabulary);
 
     if (badTag) {
@@ -224,7 +263,9 @@ export function contentRowFor(
     }
 
     // After the Locale check, deliberately: a draft that carries no Locale is
-    // not seeded at all, so the manifest has no reason to list it.
+    // not seeded at all, so the manifest has no reason to list it. A draft
+    // declared with `draft: true`, by contrast, is listed exactly like a
+    // published Part — see the check at the end of this branch.
     if (placed.container !== null && !part) {
       return {
         error: `${relativePath} is not listed in the ${placed.container} manifest — a Part nothing indexes cannot be reached or ordered`,
@@ -235,6 +276,14 @@ export function contentRowFor(
 
     if ("error" in revisions) {
       return { error: `${relativePath}: ${revisions.error}` };
+    }
+
+    // The last check in the branch, deliberately: a Draft passes every check
+    // a published document passes — its type against its placement, its Tags
+    // against the vocabulary, its manifest listing, its revisions — and only
+    // once all of them pass does it produce nothing.
+    if (isDraft(attributes.draft)) {
+      return { reason: `${relativePath} is a draft` };
     }
 
     // Written here or written as NULL, never read from front matter. The three
@@ -268,15 +317,20 @@ VALUES (${escapedSlug}, ${escapeSql(lang)}, 'post', ${title}, ${escapeSql(attrib
     return { error: `${relativePath} is a Bookmark and cannot carry updates — the body is not here` };
   }
 
-  // Checked here rather than above the branch, because a Bookmark has no draft
-  // state to step around: it is a single file with no Locale, so every one of
-  // them is seeded and every one of them is measured. The vocabulary covers
-  // Bookmarks even though no Tag page lists them, so the day that question is
-  // reopened there is nothing to clean up first.
+  // A Bookmark has no Locale to hide behind, unlike the `.en-old.md`
+  // convention a Post can use — `draft: true` is the only way one goes
+  // unpublished. The vocabulary covers Bookmarks even though no Tag page
+  // lists them, so the day that question is reopened there is nothing to
+  // clean up first.
   const badTag = tagError(relativePath, attributes.tags, vocabulary);
 
   if (badTag) {
     return { error: badTag };
+  }
+
+  // The last check, as on a Post: every other rule has already run.
+  if (isDraft(attributes.draft)) {
+    return { reason: `${relativePath} is a draft` };
   }
 
   return {

--- a/seed/d1/seed-sql.ts
+++ b/seed/d1/seed-sql.ts
@@ -240,13 +240,20 @@ export function contentRowFor(
     // Written here or written as NULL, never read from front matter. The three
     // always travel together, which is why the invariant that they are all
     // present or all absent is not checked anywhere: it is not representable.
+    //
+    // The position is written twice, once per order column: `container_order`
+    // is the one every query reads, and `section_order` is written beside it,
+    // unread, only because the previously deployed Worker still asks for it by
+    // that name during this publication's migrate-then-deploy window (ADR
+    // 0006's amendment). Dropped, and this duplication with it, once that
+    // publication is confirmed live.
     const container = part
-      ? `${escapeSql(part.seriesSlug)}, ${escapeSql(part.section)}, ${part.order}`
-      : "NULL, NULL, NULL";
+      ? `${escapeSql(part.seriesSlug)}, ${escapeSql(part.section)}, ${part.order}, ${part.order}`
+      : "NULL, NULL, NULL, NULL";
 
     return {
       statement: `
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)
 VALUES (${escapedSlug}, ${escapeSql(lang)}, 'post', ${title}, ${escapeSql(attributes.description)}, ${publishedAt}, ${escapeSql(attributes.repository)}, ${escapeSql(JSON.stringify(revisions.revisions))}, ${container}, CURRENT_TIMESTAMP);
 `,
       key: `${slug}:${lang}`,

--- a/seed/d1/seed-sql.ts
+++ b/seed/d1/seed-sql.ts
@@ -49,6 +49,33 @@ export interface PartPlacement {
   order: number;
 }
 
+/**
+ * Where a Field Note sits in its Project — `PartPlacement`'s sibling, with no
+ * section: a Project's manifest is a flat list, not an arc (Part 8 of
+ * `evolution-plan/14-phase-1b-field-notes.md`). A Project accumulates because
+ * the problems turn up when they turn up; a Series orders because it promised
+ * a Destination.
+ */
+export interface NotePlacement {
+  projectSlug: string;
+  /** The position in the manifest's list — an index, never written by hand. */
+  order: number;
+}
+
+/**
+ * A Post's Container, as the manifest that holds it hands it over: a Part's
+ * placement in its Series, or a Field Note's in its Project — never both, the
+ * same way `content.series_slug` and `content.project_slug` never both hold a
+ * value (`schema.sql`). Which one a value is is read structurally, by the
+ * field only that kind carries, rather than by a `kind` tag neither manifest
+ * writes.
+ */
+export type ContainerPlacement = PartPlacement | NotePlacement;
+
+function isPartPlacement(container: ContainerPlacement): container is PartPlacement {
+  return "seriesSlug" in container;
+}
+
 /** A row that will be seeded, and the identity used to decide it survives a prune. */
 export type SeededRow = {
   statement: string;
@@ -208,9 +235,11 @@ VALUES (${escapeSql(slug)}, ${escapeSql(lang)}, ${escapeSql(tag)});
  * shape every other front-matter mistake already fails in, rather than in a path
  * of its own.
  *
- * `part` is supplied by the caller for a Post that lives inside a Series,
- * because only the manifest knows where it sits. A nested Post without one is a
- * Part nothing indexes, which is a failure rather than a loose Post.
+ * `container` is supplied by the caller for a Post that lives inside a Series
+ * or a Project, because only the manifest knows where it sits — a Part's
+ * placement or a Field Note's, never both. A nested Post without one is a Part
+ * or a Field Note nothing indexes, which is a failure rather than a loose
+ * Post.
  *
  * `options.includeDrafts` is `preview:drafts`'s hook (see `DraftOptions`): every
  * check above the two Draft checks below still runs unconditionally, so a
@@ -220,7 +249,7 @@ export function contentRowFor(
   relativePath: string,
   attributes: FrontMatterAttributes,
   vocabulary: TagVocabulary,
-  part?: PartPlacement,
+  container?: ContainerPlacement,
   options?: DraftOptions,
 ): ContentFileResult {
   const placed = placementOf(relativePath);
@@ -282,8 +311,8 @@ export function contentRowFor(
     // After the Locale check, deliberately: a draft that carries no Locale is
     // not seeded at all, so the manifest has no reason to list it. A draft
     // declared with `draft: true`, by contrast, is listed exactly like a
-    // published Part — see the check at the end of this branch.
-    if (placed.container !== null && !part) {
+    // published Part or Field Note — see the check at the end of this branch.
+    if (placed.container !== null && !container) {
       return {
         error: `${relativePath} is not listed in the ${placed.container} manifest — a Part nothing indexes cannot be reached or ordered`,
       };
@@ -304,9 +333,11 @@ export function contentRowFor(
       return { reason: `${relativePath} is a draft` };
     }
 
-    // Written here or written as NULL, never read from front matter. The three
-    // always travel together, which is why the invariant that they are all
-    // present or all absent is not checked anywhere: it is not representable.
+    // Written here or written as NULL, never read from front matter. The
+    // three Series columns always travel together, and so do the two Project
+    // ones — a Post's Container is a Part's placement or a Field Note's,
+    // never both — which is why the invariant that they are all present or
+    // all absent is not checked anywhere: it is not representable.
     //
     // The position is written twice, once per order column: `container_order`
     // is the one every query reads, and `section_order` is written beside it,
@@ -314,14 +345,16 @@ export function contentRowFor(
     // that name during this publication's migrate-then-deploy window (ADR
     // 0006's amendment). Dropped, and this duplication with it, once that
     // publication is confirmed live.
-    const container = part
-      ? `${escapeSql(part.seriesSlug)}, ${escapeSql(part.section)}, ${part.order}, ${part.order}`
-      : "NULL, NULL, NULL, NULL";
+    const containerColumns = !container
+      ? "NULL, NULL, NULL, NULL, NULL"
+      : isPartPlacement(container)
+        ? `${escapeSql(container.seriesSlug)}, ${escapeSql(container.section)}, NULL, ${container.order}, ${container.order}`
+        : `NULL, NULL, ${escapeSql(container.projectSlug)}, ${container.order}, ${container.order}`;
 
     return {
       statement: `
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)
-VALUES (${escapedSlug}, ${escapeSql(lang)}, 'post', ${title}, ${escapeSql(attributes.description)}, ${publishedAt}, ${escapeSql(attributes.repository)}, ${escapeSql(JSON.stringify(revisions.revisions))}, ${container}, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, project_slug, section_order, container_order, updated_at)
+VALUES (${escapedSlug}, ${escapeSql(lang)}, 'post', ${title}, ${escapeSql(attributes.description)}, ${publishedAt}, ${escapeSql(attributes.repository)}, ${escapeSql(JSON.stringify(revisions.revisions))}, ${containerColumns}, CURRENT_TIMESTAMP);
 `,
       key: `${slug}:${lang}`,
       tags: tagRowsFor(slug, lang, attributes.tags),

--- a/seed/d1/seed-sql.ts
+++ b/seed/d1/seed-sql.ts
@@ -203,7 +203,6 @@ export function contentRowFor(
   }
 
   const { slug, lang } = parsed;
-  const tagsJson = escapeSql(JSON.stringify(attributes.tags || []));
   const escapedSlug = escapeSql(slug);
   const publishedAt = escapeSql(attributes.publishedAt);
   const title = escapeSql(attributes.title);
@@ -247,8 +246,8 @@ export function contentRowFor(
 
     return {
       statement: `
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, tags, repository, updates, series_slug, series_section, section_order, updated_at)
-VALUES (${escapedSlug}, ${escapeSql(lang)}, 'post', ${title}, ${escapeSql(attributes.description)}, ${publishedAt}, ${tagsJson}, ${escapeSql(attributes.repository)}, ${escapeSql(JSON.stringify(revisions.revisions))}, ${container}, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)
+VALUES (${escapedSlug}, ${escapeSql(lang)}, 'post', ${title}, ${escapeSql(attributes.description)}, ${publishedAt}, ${escapeSql(attributes.repository)}, ${escapeSql(JSON.stringify(revisions.revisions))}, ${container}, CURRENT_TIMESTAMP);
 `,
       key: `${slug}:${lang}`,
       tags: tagRowsFor(slug, lang, attributes.tags),
@@ -275,8 +274,8 @@ VALUES (${escapedSlug}, ${escapeSql(lang)}, 'post', ${title}, ${escapeSql(attrib
 
   return {
     statement: `
-INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, tags, updated_at)
-VALUES (${escapedSlug}, NULL, 'link', ${title}, ${escapeSql(attributes.externalUrl)}, ${escapeSql(attributes.source)}, ${publishedAt}, ${tagsJson}, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
+VALUES (${escapedSlug}, NULL, 'link', ${title}, ${escapeSql(attributes.externalUrl)}, ${escapeSql(attributes.source)}, ${publishedAt}, CURRENT_TIMESTAMP);
 `,
     key: `${slug}:`,
     tags: tagRowsFor(slug, null, attributes.tags),

--- a/seed/d1/seed-sql.ts
+++ b/seed/d1/seed-sql.ts
@@ -158,6 +158,18 @@ export function isDraft(draft: unknown): boolean {
 }
 
 /**
+ * The one switch every row builder in this file and its siblings takes, and
+ * the whole of what `preview:drafts` (Part 3 of the field notes) adds to the
+ * generators: with it unset or `false`, a Draft is skipped exactly as it is
+ * today. Set, a Draft is read as though it were published — checked the same
+ * way, emitted instead of skipped — which is what lets it render at its real
+ * address without touching a tracked file.
+ */
+export interface DraftOptions {
+  includeDrafts?: boolean;
+}
+
+/**
  * One `content_tag` row per Tag the file carries.
  *
  * Written for Posts and Bookmarks alike, and for a Part exactly as for a loose
@@ -199,12 +211,17 @@ VALUES (${escapeSql(slug)}, ${escapeSql(lang)}, ${escapeSql(tag)});
  * `part` is supplied by the caller for a Post that lives inside a Series,
  * because only the manifest knows where it sits. A nested Post without one is a
  * Part nothing indexes, which is a failure rather than a loose Post.
+ *
+ * `options.includeDrafts` is `preview:drafts`'s hook (see `DraftOptions`): every
+ * check above the two Draft checks below still runs unconditionally, so a
+ * broken draft fails the build in preview exactly as it would on publish.
  */
 export function contentRowFor(
   relativePath: string,
   attributes: FrontMatterAttributes,
   vocabulary: TagVocabulary,
   part?: PartPlacement,
+  options?: DraftOptions,
 ): ContentFileResult {
   const placed = placementOf(relativePath);
 
@@ -281,8 +298,9 @@ export function contentRowFor(
     // The last check in the branch, deliberately: a Draft passes every check
     // a published document passes — its type against its placement, its Tags
     // against the vocabulary, its manifest listing, its revisions — and only
-    // once all of them pass does it produce nothing.
-    if (isDraft(attributes.draft)) {
+    // once all of them pass does it produce nothing, unless the caller asked
+    // for Drafts to be included.
+    if (isDraft(attributes.draft) && !options?.includeDrafts) {
       return { reason: `${relativePath} is a draft` };
     }
 
@@ -329,7 +347,7 @@ VALUES (${escapedSlug}, ${escapeSql(lang)}, 'post', ${title}, ${escapeSql(attrib
   }
 
   // The last check, as on a Post: every other rule has already run.
-  if (isDraft(attributes.draft)) {
+  if (isDraft(attributes.draft) && !options?.includeDrafts) {
     return { reason: `${relativePath} is a draft` };
   }
 

--- a/seed/d1/seed.sql
+++ b/seed/d1/seed.sql
@@ -1,39 +1,39 @@
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, tags, repository, updates, series_slug, series_section, section_order, updated_at)
-VALUES ('implementing-value-objects-in-nodejs', 'en', 'post', 'Implementing Value Objects in Node.js', 'A practical guide to implementing Value Objects in TypeScript and Node.js to create more robust and expressive domain models, inspired by Domain-Driven Design principles.', '2025-11-02', '["nodejs","typescript","ddd","software-architecture","value-object"]', 'https://github.com/poschuler/nodejs-ddd-value-objects', '[]', NULL, NULL, NULL, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)
+VALUES ('implementing-value-objects-in-nodejs', 'en', 'post', 'Implementing Value Objects in Node.js', 'A practical guide to implementing Value Objects in TypeScript and Node.js to create more robust and expressive domain models, inspired by Domain-Driven Design principles.', '2025-11-02', 'https://github.com/poschuler/nodejs-ddd-value-objects', '[]', NULL, NULL, NULL, CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, tags, updated_at)
-VALUES ('how-i-would-do-auth', NULL, 'link', 'How I would do auth', 'https://pilcrowonpaper.com/blog/how-i-would-do-auth/', 'pilcrow', '2024-07-31', '["auth","security","webdev"]', CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
+VALUES ('how-i-would-do-auth', NULL, 'link', 'How I would do auth', 'https://pilcrowonpaper.com/blog/how-i-would-do-auth/', 'pilcrow', '2024-07-31', CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, tags, updated_at)
-VALUES ('let-me-be', NULL, 'link', 'Let me be', 'https://www.epicweb.dev/talks/let-me-be', 'Epic Web', '2024-05-04', '["javascript","typescript","webdev"]', CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
+VALUES ('let-me-be', NULL, 'link', 'Let me be', 'https://www.epicweb.dev/talks/let-me-be', 'Epic Web', '2024-05-04', CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, tags, updated_at)
-VALUES ('making-sense-of-typescript-generics', NULL, 'link', 'Making Sense of TypeScript Generics', 'https://kettanaito.com/blog/making-sense-of-typescript-generics', 'kettanaito', '2024-05-31', '["typescript","generics","webdev"]', CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
+VALUES ('making-sense-of-typescript-generics', NULL, 'link', 'Making Sense of TypeScript Generics', 'https://kettanaito.com/blog/making-sense-of-typescript-generics', 'kettanaito', '2024-05-31', CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, tags, updated_at)
-VALUES ('migrating-from-radix-to-react-aria-improving-accessibility-and-ux', NULL, 'link', 'Migrating from Radix to React Aria: Improving Accessibility and UX', 'https://argos-ci.com/blog/react-aria-migration', 'argos CI', '2024-05-28', '["react-aria","radix","accessibility","webdev","ux"]', CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
+VALUES ('migrating-from-radix-to-react-aria-improving-accessibility-and-ux', NULL, 'link', 'Migrating from Radix to React Aria: Improving Accessibility and UX', 'https://argos-ci.com/blog/react-aria-migration', 'argos CI', '2024-05-28', CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, tags, updated_at)
-VALUES ('navigating-the-future-of-frontend', NULL, 'link', 'Navigating the future of frontend', 'https://frontendmastery.com/posts/navigating-the-future-of-frontend/', 'Frontend Mastery', '2024-04-23', '["frontend","javascript","typescript","webdev"]', CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
+VALUES ('navigating-the-future-of-frontend', NULL, 'link', 'Navigating the future of frontend', 'https://frontendmastery.com/posts/navigating-the-future-of-frontend/', 'Frontend Mastery', '2024-04-23', CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, tags, updated_at)
-VALUES ('oops-i-accidentally-made-our-website-faster-by-switching-to-remix', NULL, 'link', 'Oops, I accidentally made our website faster by switching to Remix', 'https://echobind.com/post/oops-i-accidentally-made-our-website-faster-by-switching-to-remix', 'Echobind', '2024-09-03', '["remix","performance","webdev"]', CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
+VALUES ('oops-i-accidentally-made-our-website-faster-by-switching-to-remix', NULL, 'link', 'Oops, I accidentally made our website faster by switching to Remix', 'https://echobind.com/post/oops-i-accidentally-made-our-website-faster-by-switching-to-remix', 'Echobind', '2024-09-03', CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, tags, updated_at)
-VALUES ('stop-lying-to-your-users', NULL, 'link', 'Stop Lying to Your Users', 'https://www.epicweb.dev/stop-lying-to-your-users', 'Epic Web', '2024-04-24', '["javascript","typescript","webdev"]', CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
+VALUES ('stop-lying-to-your-users', NULL, 'link', 'Stop Lying to Your Users', 'https://www.epicweb.dev/stop-lying-to-your-users', 'Epic Web', '2024-04-24', CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, tags, updated_at)
-VALUES ('the-copenhagen-book', NULL, 'link', 'The Copenhagen Book', 'https://thecopenhagenbook.com/', 'pilcrow', '2024-07-30', '["auth","security","webdev"]', CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
+VALUES ('the-copenhagen-book', NULL, 'link', 'The Copenhagen Book', 'https://thecopenhagenbook.com/', 'pilcrow', '2024-07-30', CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, tags, repository, updates, series_slug, series_section, section_order, updated_at)
-VALUES ('project-setup', 'en', 'post', 'Setup Node.js, Express & TypeScript Project in 2026', 'The definitive starting point for your next project. Learn to setup Node.js, Express, and TypeScript using a professional, class-based architecture designed for long-term maintainability and scale.', '2025-12-25', '["nodejs","typescript","express","backend"]', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/initial-project-setup', '[]', 'pragmatic-nodejs-api', 'fundamentals', 0, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)
+VALUES ('project-setup', 'en', 'post', 'Setup Node.js, Express & TypeScript Project in 2026', 'The definitive starting point for your next project. Learn to setup Node.js, Express, and TypeScript using a professional, class-based architecture designed for long-term maintainability and scale.', '2025-12-25', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/initial-project-setup', '[]', 'pragmatic-nodejs-api', 'fundamentals', 0, CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, tags, repository, updates, series_slug, series_section, section_order, updated_at)
-VALUES ('schema-validation-and-error-handling', 'en', 'post', 'Schema Validation and Global Error Handling', 'Standardize your API integrity by implementing Zod for type-safe validation and a centralized error-handling middleware.', '2025-12-27', '["nodejs","typescript","express","backend","zod","error-handling"]', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/validation-error-handling', '[]', 'pragmatic-nodejs-api', 'fundamentals', 1, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)
+VALUES ('schema-validation-and-error-handling', 'en', 'post', 'Schema Validation and Global Error Handling', 'Standardize your API integrity by implementing Zod for type-safe validation and a centralized error-handling middleware.', '2025-12-27', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/validation-error-handling', '[]', 'pragmatic-nodejs-api', 'fundamentals', 1, CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, tags, repository, updates, series_slug, series_section, section_order, updated_at)
-VALUES ('vertical-slices-and-domain-logic', 'en', 'post', 'Vertical Slices Architecture and Domain Logic', 'Organize your Node.js API using Vertical Slices to encapsulate features and maintain a clear separation of concerns, enhancing maintainability and scalability.', '2026-02-20', '["nodejs","typescript","express","backend","vertical-slices","software-architecture"]', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/vertical-slices-and-domain-logic', '[]', 'pragmatic-nodejs-api', 'fundamentals', 2, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)
+VALUES ('vertical-slices-and-domain-logic', 'en', 'post', 'Vertical Slices Architecture and Domain Logic', 'Organize your Node.js API using Vertical Slices to encapsulate features and maintain a clear separation of concerns, enhancing maintainability and scalability.', '2026-02-20', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/vertical-slices-and-domain-logic', '[]', 'pragmatic-nodejs-api', 'fundamentals', 2, CURRENT_TIMESTAMP);
 
 INSERT OR REPLACE INTO content_tag (slug, lang, tag)
 VALUES ('implementing-value-objects-in-nodejs', 'en', 'nodejs');

--- a/seed/d1/seed.sql
+++ b/seed/d1/seed.sql
@@ -1,6 +1,6 @@
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)
-VALUES ('implementing-value-objects-in-nodejs', 'en', 'post', 'Implementing Value Objects in Node.js', 'A practical guide to implementing Value Objects in TypeScript and Node.js to create more robust and expressive domain models, inspired by Domain-Driven Design principles.', '2025-11-02', 'https://github.com/poschuler/nodejs-ddd-value-objects', '[]', NULL, NULL, NULL, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)
+VALUES ('implementing-value-objects-in-nodejs', 'en', 'post', 'Implementing Value Objects in Node.js', 'A practical guide to implementing Value Objects in TypeScript and Node.js to create more robust and expressive domain models, inspired by Domain-Driven Design principles.', '2025-11-02', 'https://github.com/poschuler/nodejs-ddd-value-objects', '[]', NULL, NULL, NULL, NULL, CURRENT_TIMESTAMP);
 
 INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
 VALUES ('how-i-would-do-auth', NULL, 'link', 'How I would do auth', 'https://pilcrowonpaper.com/blog/how-i-would-do-auth/', 'pilcrow', '2024-07-31', CURRENT_TIMESTAMP);
@@ -26,14 +26,14 @@ VALUES ('stop-lying-to-your-users', NULL, 'link', 'Stop Lying to Your Users', 'h
 INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
 VALUES ('the-copenhagen-book', NULL, 'link', 'The Copenhagen Book', 'https://thecopenhagenbook.com/', 'pilcrow', '2024-07-30', CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)
-VALUES ('project-setup', 'en', 'post', 'Setup Node.js, Express & TypeScript Project in 2026', 'The definitive starting point for your next project. Learn to setup Node.js, Express, and TypeScript using a professional, class-based architecture designed for long-term maintainability and scale.', '2025-12-25', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/initial-project-setup', '[]', 'pragmatic-nodejs-api', 'fundamentals', 0, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)
+VALUES ('project-setup', 'en', 'post', 'Setup Node.js, Express & TypeScript Project in 2026', 'The definitive starting point for your next project. Learn to setup Node.js, Express, and TypeScript using a professional, class-based architecture designed for long-term maintainability and scale.', '2025-12-25', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/initial-project-setup', '[]', 'pragmatic-nodejs-api', 'fundamentals', 0, 0, CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)
-VALUES ('schema-validation-and-error-handling', 'en', 'post', 'Schema Validation and Global Error Handling', 'Standardize your API integrity by implementing Zod for type-safe validation and a centralized error-handling middleware.', '2025-12-27', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/validation-error-handling', '[]', 'pragmatic-nodejs-api', 'fundamentals', 1, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)
+VALUES ('schema-validation-and-error-handling', 'en', 'post', 'Schema Validation and Global Error Handling', 'Standardize your API integrity by implementing Zod for type-safe validation and a centralized error-handling middleware.', '2025-12-27', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/validation-error-handling', '[]', 'pragmatic-nodejs-api', 'fundamentals', 1, 1, CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)
-VALUES ('vertical-slices-and-domain-logic', 'en', 'post', 'Vertical Slices Architecture and Domain Logic', 'Organize your Node.js API using Vertical Slices to encapsulate features and maintain a clear separation of concerns, enhancing maintainability and scalability.', '2026-02-20', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/vertical-slices-and-domain-logic', '[]', 'pragmatic-nodejs-api', 'fundamentals', 2, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)
+VALUES ('vertical-slices-and-domain-logic', 'en', 'post', 'Vertical Slices Architecture and Domain Logic', 'Organize your Node.js API using Vertical Slices to encapsulate features and maintain a clear separation of concerns, enhancing maintainability and scalability.', '2026-02-20', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/vertical-slices-and-domain-logic', '[]', 'pragmatic-nodejs-api', 'fundamentals', 2, 2, CURRENT_TIMESTAMP);
 
 INSERT OR REPLACE INTO content_tag (slug, lang, tag)
 VALUES ('implementing-value-objects-in-nodejs', 'en', 'nodejs');

--- a/seed/d1/seed.sql
+++ b/seed/d1/seed.sql
@@ -1,6 +1,6 @@
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)
-VALUES ('implementing-value-objects-in-nodejs', 'en', 'post', 'Implementing Value Objects in Node.js', 'A practical guide to implementing Value Objects in TypeScript and Node.js to create more robust and expressive domain models, inspired by Domain-Driven Design principles.', '2025-11-02', 'https://github.com/poschuler/nodejs-ddd-value-objects', '[]', NULL, NULL, NULL, NULL, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, project_slug, section_order, container_order, updated_at)
+VALUES ('implementing-value-objects-in-nodejs', 'en', 'post', 'Implementing Value Objects in Node.js', 'A practical guide to implementing Value Objects in TypeScript and Node.js to create more robust and expressive domain models, inspired by Domain-Driven Design principles.', '2025-11-02', 'https://github.com/poschuler/nodejs-ddd-value-objects', '[]', NULL, NULL, NULL, NULL, NULL, CURRENT_TIMESTAMP);
 
 INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
 VALUES ('how-i-would-do-auth', NULL, 'link', 'How I would do auth', 'https://pilcrowonpaper.com/blog/how-i-would-do-auth/', 'pilcrow', '2024-07-31', CURRENT_TIMESTAMP);
@@ -26,14 +26,14 @@ VALUES ('stop-lying-to-your-users', NULL, 'link', 'Stop Lying to Your Users', 'h
 INSERT OR REPLACE INTO content (slug, lang, type, title, external_url, source, published_at, updated_at)
 VALUES ('the-copenhagen-book', NULL, 'link', 'The Copenhagen Book', 'https://thecopenhagenbook.com/', 'pilcrow', '2024-07-30', CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)
-VALUES ('project-setup', 'en', 'post', 'Setup Node.js, Express & TypeScript Project in 2026', 'The definitive starting point for your next project. Learn to setup Node.js, Express, and TypeScript using a professional, class-based architecture designed for long-term maintainability and scale.', '2025-12-25', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/initial-project-setup', '[]', 'pragmatic-nodejs-api', 'fundamentals', 0, 0, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, project_slug, section_order, container_order, updated_at)
+VALUES ('project-setup', 'en', 'post', 'Setup Node.js, Express & TypeScript Project in 2026', 'The definitive starting point for your next project. Learn to setup Node.js, Express, and TypeScript using a professional, class-based architecture designed for long-term maintainability and scale.', '2025-12-25', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/initial-project-setup', '[]', 'pragmatic-nodejs-api', 'fundamentals', NULL, 0, 0, CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)
-VALUES ('schema-validation-and-error-handling', 'en', 'post', 'Schema Validation and Global Error Handling', 'Standardize your API integrity by implementing Zod for type-safe validation and a centralized error-handling middleware.', '2025-12-27', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/validation-error-handling', '[]', 'pragmatic-nodejs-api', 'fundamentals', 1, 1, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, project_slug, section_order, container_order, updated_at)
+VALUES ('schema-validation-and-error-handling', 'en', 'post', 'Schema Validation and Global Error Handling', 'Standardize your API integrity by implementing Zod for type-safe validation and a centralized error-handling middleware.', '2025-12-27', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/validation-error-handling', '[]', 'pragmatic-nodejs-api', 'fundamentals', NULL, 1, 1, CURRENT_TIMESTAMP);
 
-INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)
-VALUES ('vertical-slices-and-domain-logic', 'en', 'post', 'Vertical Slices Architecture and Domain Logic', 'Organize your Node.js API using Vertical Slices to encapsulate features and maintain a clear separation of concerns, enhancing maintainability and scalability.', '2026-02-20', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/vertical-slices-and-domain-logic', '[]', 'pragmatic-nodejs-api', 'fundamentals', 2, 2, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO content (slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, project_slug, section_order, container_order, updated_at)
+VALUES ('vertical-slices-and-domain-logic', 'en', 'post', 'Vertical Slices Architecture and Domain Logic', 'Organize your Node.js API using Vertical Slices to encapsulate features and maintain a clear separation of concerns, enhancing maintainability and scalability.', '2026-02-20', 'https://github.com/poschuler/pragmatic-nodejs-api/tree/feature/vertical-slices-and-domain-logic', '[]', 'pragmatic-nodejs-api', 'fundamentals', NULL, 2, 2, CURRENT_TIMESTAMP);
 
 INSERT OR REPLACE INTO content_tag (slug, lang, tag)
 VALUES ('implementing-value-objects-in-nodejs', 'en', 'nodejs');

--- a/seed/d1/series-sql.ts
+++ b/seed/d1/series-sql.ts
@@ -16,7 +16,9 @@
 
 import { basenameOf, declaredTypeMatches, isMisplaced, placementOf } from "./content-tree.ts";
 import {
+  draftError,
   escapeSql,
+  isDraft,
   parseContentFilename,
   type InvalidFile,
   type PartPlacement,
@@ -61,6 +63,8 @@ export interface SeriesFrontMatter {
   outOfScope: unknown;
   audience: string;
   sections: unknown;
+  /** `unknown` for the same reason as on a Post — see `draftError`. */
+  draft?: unknown;
 }
 
 /** A Markdown file found under a Series folder, already parsed. */
@@ -71,6 +75,14 @@ export interface SeriesPartFile {
   /** The folder it sits in — its own name, per the rule in `content-tree.ts`. */
   folder: string;
   relativePath: string;
+  /**
+   * Whether this Part's own front matter declares `draft: true`. Read leniently
+   * here — the definitive check that the value is a boolean at all happens
+   * where the Part's own row is built, in `contentRowFor` — because all this
+   * needs is to tell a published Part from an unpublished one for the
+   * Container-contradiction check below.
+   */
+  draft: boolean;
 }
 
 export interface SeriesRows {
@@ -82,6 +94,14 @@ export interface SeriesRows {
   sections: SeededRow[];
   /** Part Slug → where the manifest says it sits. */
   parts: Map<string, PartPlacement>;
+  /**
+   * Whether this manifest declared itself a Draft. `series` and `sections`
+   * above are still built when it did — the caller decides whether to seed
+   * them — because `parts` is needed either way: a drafted Container's Parts,
+   * which must themselves be Drafts (see the Container-contradiction check),
+   * still have to be listed and reconciled like any other.
+   */
+  draft: boolean;
 }
 
 export type SeriesResult = SeriesRows | InvalidFile;
@@ -217,12 +237,36 @@ function reconcileError(
 }
 
 /**
+ * A Container may be a Draft only while it holds no published content (Part 5
+ * of `evolution-plan/14-phase-1b-field-notes.md`). There is no cascade: a
+ * drafted Series does not hide its published Parts, it refuses to coexist
+ * with them.
+ *
+ * `partFiles` here is only ever the files that would otherwise be reconciled
+ * against this manifest, so an unlisted or misfiled Part has already failed
+ * elsewhere by the time this runs.
+ */
+function containerContradictionError(
+  relativePath: string,
+  partFiles: SeriesPartFile[],
+): string | null {
+  const published = partFiles.find((file) => !file.draft);
+
+  if (!published) {
+    return null;
+  }
+
+  return `${relativePath} is a draft, but '${published.slug}' is published — a Post cannot be reached through a Container that is not.`;
+}
+
+/**
  * The rows for one Series manifest, or the reason the build should stop.
  *
  * `partFiles` is every Markdown file under this Series folder that carries this
- * manifest's Locale and a recognised one at all. A draft — the `.en-old.md`
- * shape — parses to no Locale, is never seeded, and so is not reconciled
- * against the manifest either.
+ * manifest's Locale and a recognised one at all. A draft filed under the
+ * `.en-old.md` convention parses to no Locale, is never seeded, and so is not
+ * reconciled against the manifest either — a draft declared with
+ * `draft: true`, by contrast, is reconciled exactly like a published Part.
  */
 export function seriesRowsFor(
   relativePath: string,
@@ -254,10 +298,17 @@ export function seriesRowsFor(
 
   const { slug, lang } = parsed;
 
-  // No skip branch, as on a Project: a Series landing has no draft state. It is
-  // one page, revised in place, so a missing Locale is a mistake.
+  // A Series landing has no `.en-old.md` convention to hide behind, as on a
+  // Project: it is one page, revised in place, so a missing Locale is a
+  // mistake. `draft: true` is the only way one goes unpublished.
   if (!lang) {
     return { error: `${relativePath} must have a language in its filename` };
+  }
+
+  const draftProblem = draftError(relativePath, attributes.draft);
+
+  if (draftProblem) {
+    return { error: draftProblem };
   }
 
   // The landing renders the contract, the sections and the Parts from data. The
@@ -301,6 +352,14 @@ export function seriesRowsFor(
     return { error: reconcile };
   }
 
+  if (isDraft(attributes.draft)) {
+    const contradiction = containerContradictionError(relativePath, partFiles);
+
+    if (contradiction) {
+      return { error: contradiction };
+    }
+  }
+
   const series: SeededRow = {
     statement: `
 INSERT OR REPLACE INTO series (slug, lang, title, description, status, starting_point, destination, out_of_scope, audience, updated_at)
@@ -326,11 +385,12 @@ VALUES (${escapeSql(slug)}, ${escapeSql(lang)}, ${escapeSql(section.slug)}, ${es
     });
   });
 
-  return { slug, lang, series, sections: sectionRows, parts };
+  return { slug, lang, series, sections: sectionRows, parts, draft: isDraft(attributes.draft) };
 }
 
 /**
- * Inserts first, prune last, and nothing at all when there are no Series.
+ * Inserts first, prune last, and nothing at all when there are no Series —
+ * unless `anyFilesFound` says otherwise.
  *
  * Both prunes are needed and neither is optional: a section removed from a
  * manifest would otherwise stay alive in the database and keep rendering on the
@@ -338,10 +398,17 @@ VALUES (${escapeSql(slug)}, ${escapeSql(lang)}, ${escapeSql(section.slug)}, ${es
  *
  * The guard on an empty list is `project-sql.ts`'s, for its reason: a repo with
  * no Series is an ordinary state, and a prune built from an empty list deletes
- * every row on the strength of finding nothing.
+ * every row on the strength of finding nothing. And `anyFilesFound` is
+ * `project-sql.ts`'s too, for the same reason: every Series this walk found
+ * may have declared `draft: true`, in which case a previously published one
+ * must still be pruned even though `seriesRows` came back empty.
  */
-export function buildSeriesSeedSql(seriesRows: SeededRow[], sectionRows: SeededRow[]): string {
-  if (seriesRows.length === 0) {
+export function buildSeriesSeedSql(
+  seriesRows: SeededRow[],
+  sectionRows: SeededRow[],
+  { anyFilesFound = false }: { anyFilesFound?: boolean } = {},
+): string {
+  if (seriesRows.length === 0 && !anyFilesFound) {
     return "";
   }
 

--- a/seed/d1/series-sql.ts
+++ b/seed/d1/series-sql.ts
@@ -15,6 +15,7 @@
  */
 
 import { basenameOf, declaredTypeMatches, isMisplaced, placementOf } from "./content-tree.ts";
+import { containerContradictionError, reconcileManifest } from "./manifest.ts";
 import {
   draftError,
   escapeSql,
@@ -187,13 +188,18 @@ function sectionsError(
  * shared position — which stopped being representable the moment order became a
  * list. It catches the thing that actually happens: writing a Part and
  * forgetting to index it, which would publish a page nothing links to.
+ *
+ * The emptiness check stays here, because the message it produces names the
+ * section — `manifest.ts`'s shared `reconcileManifest` takes over once every
+ * entry is known to be a real Slug, and is where 1b's Project manifest
+ * reconciles the same way (Part 8 of the field notes).
  */
 function reconcileError(
   relativePath: string,
   sections: SeriesSectionFrontMatter[],
   partFiles: SeriesPartFile[],
 ): string | null {
-  const listed = new Map<string, string>();
+  const entries: { slug: string; where: string }[] = [];
 
   for (const section of sections) {
     for (const slug of section.parts ?? []) {
@@ -201,62 +207,11 @@ function reconcileError(
         return `${relativePath} section '${section.slug}' lists an empty Part`;
       }
 
-      const already = listed.get(slug);
-
-      if (already !== undefined) {
-        return `${relativePath} lists the Part '${slug}' in both '${already}' and '${section.slug}' — a Part belongs to one section`;
-      }
-
-      listed.set(slug, section.slug);
+      entries.push({ slug, where: section.slug });
     }
   }
 
-  const onDisk = new Set(partFiles.map((file) => file.slug));
-
-  for (const slug of listed.keys()) {
-    if (!onDisk.has(slug)) {
-      return `${relativePath} lists the Part '${slug}', which has no file`;
-    }
-  }
-
-  for (const file of partFiles) {
-    // The rule from `content-tree.ts`: the file named after its folder is that
-    // folder. Everything downstream builds the path back from the Slug — the KV
-    // generator reads the body from `<slug>/<slug>.<lang>.md` — so a Part whose
-    // filename and folder disagree is a body nothing can find.
-    if (file.folder !== file.slug) {
-      return `${file.relativePath} is not named after its folder '${file.folder}' — nothing could find its body from the Slug`;
-    }
-
-    if (!listed.has(file.slug)) {
-      return `${file.relativePath} is not listed in ${relativePath} — a Part nothing indexes cannot be reached or ordered`;
-    }
-  }
-
-  return null;
-}
-
-/**
- * A Container may be a Draft only while it holds no published content (Part 5
- * of `evolution-plan/14-phase-1b-field-notes.md`). There is no cascade: a
- * drafted Series does not hide its published Parts, it refuses to coexist
- * with them.
- *
- * `partFiles` here is only ever the files that would otherwise be reconciled
- * against this manifest, so an unlisted or misfiled Part has already failed
- * elsewhere by the time this runs.
- */
-function containerContradictionError(
-  relativePath: string,
-  partFiles: SeriesPartFile[],
-): string | null {
-  const published = partFiles.find((file) => !file.draft);
-
-  if (!published) {
-    return null;
-  }
-
-  return `${relativePath} is a draft, but '${published.slug}' is published — a Post cannot be reached through a Container that is not.`;
+  return reconcileManifest(relativePath, entries, partFiles, "Part");
 }
 
 /**

--- a/seed/kv/generate-kv-json.ts
+++ b/seed/kv/generate-kv-json.ts
@@ -88,9 +88,7 @@ function fetchAll(): ContentRowType[] {
     // by accident. Fixing it means single-quoting the aliases, not adding
     // backslashes.
     //
-    // No `tags`, for the reason `CONTENT_COLUMNS` states at length: the column
-    // is still written and no longer read, so that dropping it is a deploy of
-    // its own rather than one that strands the Worker already serving. Nothing
+    // No `tags`: `content` has no such column since migration 0005. Nothing
     // here ever used it — a payload's Tags come from the front matter below,
     // verbatim, and the index at `/tags` is built from `content_tag`.
     const rows = queryD1<ContentRowType>(
@@ -131,9 +129,9 @@ function fetchAllSeries(): SeriesRowType[] {
 /**
  * The Tags that reach a page — the entries the index at `/tags` lists.
  *
- * Read from `content_tag` rather than from the `tags` column selected above:
- * that column has no reader left and is scheduled for removal, and the sitemap
- * would be the one thing keeping it alive.
+ * Read from `content_tag`, which is where a Tag lives. `content` carried a JSON
+ * copy until migration 0005; had the sitemap read that instead, it would have
+ * been the one thing keeping a column with no other reader alive.
  *
  * **Posts only**, because a Tag page lists Posts only — the join on `lang` does
  * that on its own (a Bookmark's is NULL in both tables and SQLite matches no

--- a/seed/kv/generate-kv-json.ts
+++ b/seed/kv/generate-kv-json.ts
@@ -24,7 +24,7 @@ import resume from "../../app/routes/resume/resume.json" with { type: "json" };
 const CONTENT_DIR = path.join(process.cwd(), "app", "content", "blog");
 const PROJECT_CONTENT_DIR = path.join(process.cwd(), "app", "content", "projects");
 const SERIES_CONTENT_DIR = path.join(process.cwd(), "app", "content", "series");
-const TEMP_JSON_DIR = path.join(process.cwd(), "seed", "kv", "kv_payloads");
+const DEFAULT_OUTPUT_DIR = path.join(process.cwd(), "seed", "kv", "kv_payloads");
 const D1_BINDING_NAME = "poschuler";
 const PUBLIC_HOST = "https://poschuler.com";
 
@@ -186,7 +186,19 @@ async function writePayload(
     );
 }
 
-async function generateKvJsonFiles() {
+/**
+ * Reads the *already seeded* local D1, writes every payload and the sitemap
+ * into `outputDir`.
+ *
+ * One parameter, not a second pipeline (Part 3 of the field notes): called
+ * with none, this is byte-for-byte what it always was. `preview:drafts` is
+ * the only caller that passes one — a directory outside `seed/kv/`, so
+ * nothing tracked is touched. There is no `includeDrafts` here: this
+ * generator does not decide what is published, it renders whatever `content`
+ * already holds, and `generate-seed-sql.ts --include-drafts` is what put a
+ * Draft's row there in the first place.
+ */
+async function generateKvJsonFiles(outputDir: string = DEFAULT_OUTPUT_DIR) {
     console.log("⚙️ Starting content processing and JSON file generation...");
 
     const allContentItems = fetchAll();
@@ -195,10 +207,10 @@ async function generateKvJsonFiles() {
     const series = fetchAllSeries();
     const tags = fetchTaggedPostTags();
 
-    await fs.rm(TEMP_JSON_DIR, { recursive: true, force: true });
-    await fs.mkdir(TEMP_JSON_DIR, { recursive: true });
+    await fs.rm(outputDir, { recursive: true, force: true });
+    await fs.mkdir(outputDir, { recursive: true });
 
-    console.log(`\n2. 📄 Found ${posts.length} posts, ${projects.length} projects and ${series.length} series. Writing JSON files to ${TEMP_JSON_DIR}...`);
+    console.log(`\n2. 📄 Found ${posts.length} posts, ${projects.length} projects and ${series.length} series. Writing JSON files to ${outputDir}...`);
 
     for (const post of posts) {
         const { slug, lang, seriesSlug } = post;
@@ -209,7 +221,7 @@ async function generateKvJsonFiles() {
             ? path.join(SERIES_CONTENT_DIR, seriesSlug, slug, `${slug}.${lang}.md`)
             : path.join(CONTENT_DIR, slug, `${slug}.${lang}.md`);
 
-        await writePayload(sourcePath, path.join(TEMP_JSON_DIR, "blog"), slug, lang);
+        await writePayload(sourcePath, path.join(outputDir, "blog"), slug, lang);
 
         console.log(`   -> ✅ JSON written for key: blog:${slug}:${lang}`);
     }
@@ -217,7 +229,7 @@ async function generateKvJsonFiles() {
     for (const { slug, lang } of series) {
         await writePayload(
             path.join(SERIES_CONTENT_DIR, slug, `${slug}.${lang}.md`),
-            path.join(TEMP_JSON_DIR, "series"),
+            path.join(outputDir, "series"),
             slug,
             lang,
         );
@@ -230,7 +242,7 @@ async function generateKvJsonFiles() {
 
         await writePayload(
             path.join(PROJECT_CONTENT_DIR, slug, `${slug}.${lang}.md`),
-            path.join(TEMP_JSON_DIR, "projects"),
+            path.join(outputDir, "projects"),
             slug,
             lang,
         );
@@ -256,7 +268,7 @@ async function generateKvJsonFiles() {
     });
 
     await fs.writeFile(
-        path.join(TEMP_JSON_DIR, `sitemap.json`),
+        path.join(outputDir, `sitemap.json`),
         JSON.stringify({ sitemap }, null, 2),
         "utf-8",
     );
@@ -266,7 +278,25 @@ async function generateKvJsonFiles() {
     console.log(`\n\n🎉 JSON generation complete! Files are ready for upload.`);
 }
 
-generateKvJsonFiles().catch((e) => {
+/**
+ * `--output-dir <dir>`, optional. Hand-parsed for the same reason as
+ * `generate-seed-sql.ts`'s — this file sits outside the coverage target.
+ */
+function parseArgs(argv: string[]): { outputDir?: string } {
+    let outputDir: string | undefined;
+
+    for (let i = 0; i < argv.length; i++) {
+        if (argv[i] === "--output-dir") {
+            outputDir = argv[++i];
+        }
+    }
+
+    return { outputDir };
+}
+
+const { outputDir } = parseArgs(process.argv.slice(2));
+
+generateKvJsonFiles(outputDir ? path.resolve(process.cwd(), outputDir) : undefined).catch((e) => {
     console.error("JSON generation failed at the top level:");
     console.error(e);
     process.exit(1);

--- a/seed/kv/generate-kv-json.ts
+++ b/seed/kv/generate-kv-json.ts
@@ -51,9 +51,11 @@ type ContentRowType = SitemapContentItem & {
     source: string;
     /**
      * The Container, when the Post has one. It is what says where the Markdown
-     * is: a Part lives under its Series, not under `blog/`.
+     * is: a Part lives under its Series, a Field Note under its Project,
+     * neither under `blog/`.
      */
     seriesSlug: string | null;
+    projectSlug: string | null;
 };
 
 type SeriesRowType = {
@@ -92,7 +94,7 @@ function fetchAll(): ContentRowType[] {
     // here ever used it — a payload's Tags come from the front matter below,
     // verbatim, and the index at `/tags` is built from `content_tag`.
     const rows = queryD1<ContentRowType>(
-        `select id_content as "idContent", slug as "slug", lang as "lang", type as "type", title as "title", published_at as "publishedAt", strftime('%Y-%m-%d', published_at) AS "publishedStringDate", description as "description", external_url as "externalUrl", source as "source", updates as "updates", series_slug as "seriesSlug" from content order by published_at desc`,
+        `select id_content as "idContent", slug as "slug", lang as "lang", type as "type", title as "title", published_at as "publishedAt", strftime('%Y-%m-%d', published_at) AS "publishedStringDate", description as "description", external_url as "externalUrl", source as "source", updates as "updates", series_slug as "seriesSlug", project_slug as "projectSlug" from content order by published_at desc`,
     );
 
     if (!rows.length) {
@@ -213,13 +215,17 @@ async function generateKvJsonFiles(outputDir: string = DEFAULT_OUTPUT_DIR) {
     console.log(`\n2. 📄 Found ${posts.length} posts, ${projects.length} projects and ${series.length} series. Writing JSON files to ${outputDir}...`);
 
     for (const post of posts) {
-        const { slug, lang, seriesSlug } = post;
+        const { slug, lang, seriesSlug, projectSlug } = post;
 
         // Where the Markdown is, which is not where the payload goes: a Part
-        // lives under its Series on disk and under `blog:` in KV.
+        // lives under its Series on disk, a Field Note under its Project, and
+        // both under `blog:` in KV — the prefix says what kind of payload it
+        // is, not which URL serves it.
         const sourcePath = seriesSlug
             ? path.join(SERIES_CONTENT_DIR, seriesSlug, slug, `${slug}.${lang}.md`)
-            : path.join(CONTENT_DIR, slug, `${slug}.${lang}.md`);
+            : projectSlug
+                ? path.join(PROJECT_CONTENT_DIR, projectSlug, slug, `${slug}.${lang}.md`)
+                : path.join(CONTENT_DIR, slug, `${slug}.${lang}.md`);
 
         await writePayload(sourcePath, path.join(outputDir, "blog"), slug, lang);
 

--- a/seed/kv/kv-bulk-upload.ts
+++ b/seed/kv/kv-bulk-upload.ts
@@ -23,7 +23,7 @@ import { listPayloadFiles } from "./payload-files.ts";
  */
 
 const KV_BINDING = "BLOG_KV";
-const JSON_DIR = path.join(process.cwd(), "seed", "kv", "kv_payloads");
+const DEFAULT_JSON_DIR = path.join(process.cwd(), "seed", "kv", "kv_payloads");
 
 function wrangler(args: string[], wranglerArgs: string[]): string {
     return execFileSync("pnpm", ["exec", "wrangler", ...args, ...wranglerArgs], {
@@ -31,16 +31,21 @@ function wrangler(args: string[], wranglerArgs: string[]): string {
     });
 }
 
-async function bulkUpload(mode: string) {
+/**
+ * `jsonDir` defaults to the committed fixtures; `preview:drafts` is the only
+ * caller that passes another, so it uploads what it just generated rather
+ * than what is on disk under `seed/kv/kv_payloads/`.
+ */
+async function bulkUpload(mode: string, jsonDir: string = DEFAULT_JSON_DIR) {
     const wranglerArgs = mode === "remote" ? ["--remote"] : ["--local"];
 
     console.log(`Starting ${mode.toUpperCase()} upload to KV binding: ${KV_BINDING}`);
 
-    if (!fs.existsSync(JSON_DIR)) {
-        throw new Error(`ERROR: Directory ${JSON_DIR} does not exist. Run 'pnpm run kv:generate' first.`);
+    if (!fs.existsSync(jsonDir)) {
+        throw new Error(`ERROR: Directory ${jsonDir} does not exist. Run 'pnpm run kv:generate' first.`);
     }
 
-    const files = await listPayloadFiles(JSON_DIR);
+    const files = await listPayloadFiles(jsonDir);
     const entries: Array<{ key: string; value: string }> = [];
 
     for (const relativePath of files) {
@@ -52,12 +57,12 @@ async function bulkUpload(mode: string) {
 
         entries.push({
             key,
-            value: await fsPromise.readFile(path.join(JSON_DIR, relativePath), "utf-8"),
+            value: await fsPromise.readFile(path.join(jsonDir, relativePath), "utf-8"),
         });
     }
 
     if (entries.length === 0) {
-        throw new Error(`ERROR: no payloads found in ${JSON_DIR}.`);
+        throw new Error(`ERROR: no payloads found in ${jsonDir}.`);
     }
 
     // One request rather than one per key: less time spent half-written, and the
@@ -106,14 +111,27 @@ async function pruneOrphans(expected: string[], wranglerArgs: string[]) {
     }
 }
 
-const modeArg = process.argv[2];
+const [modeArg, ...restArgs] = process.argv.slice(2);
 
 if (modeArg !== "local" && modeArg !== "remote") {
     console.error("ERROR: pass a mode: 'local' or 'remote'.");
     process.exit(1);
 }
 
-bulkUpload(modeArg).catch((error) => {
+/**
+ * `--output-dir <path>`, optional — see `bulkUpload`'s doc comment. Named to
+ * match the flag the two generators take, not `--dir` — the same concept,
+ * the same spelling.
+ */
+function parseDirArg(argv: string[]): string | undefined {
+    const index = argv.indexOf("--output-dir");
+
+    return index === -1 ? undefined : argv[index + 1];
+}
+
+const dirArg = parseDirArg(restArgs);
+
+bulkUpload(modeArg, dirArg ? path.resolve(process.cwd(), dirArg) : undefined).catch((error) => {
     console.error(error instanceof Error ? error.message : error);
     process.exit(1);
 });

--- a/seed/kv/sitemap-routes.ts
+++ b/seed/kv/sitemap-routes.ts
@@ -26,6 +26,12 @@ export type SitemapContentItem = {
    * since the route started redirecting.
    */
   seriesSlug?: string | null;
+  /**
+   * The other Container a Post can have — a Field Note is served under its
+   * Project the same way a Part is served under its Series, and for the same
+   * reason: `/blog/<slug>` redirects it rather than serving it.
+   */
+  projectSlug?: string | null;
 };
 
 /**
@@ -124,9 +130,11 @@ export function buildSitemapRoutes(
 ): SitemapRoute[] {
   const posts = items.filter((item) => item.type === "post");
   const bookmarks = items.filter((item) => item.type === "link");
-  // A Part is served under its Container; everything else under `/blog`.
+  // A Part or a Field Note is served under its Container; everything else
+  // under `/blog`.
   const parts = posts.filter((post) => post.seriesSlug);
-  const loosePosts = posts.filter((post) => !post.seriesSlug);
+  const notes = posts.filter((post) => post.projectSlug);
+  const loosePosts = posts.filter((post) => !post.seriesSlug && !post.projectSlug);
 
   const lastModOf = (list: SitemapContentItem[]) =>
     list.length > 0 ? list[0].publishedStringDate : fallbackLastmod;
@@ -141,6 +149,21 @@ export function buildSitemapRoutes(
     latestRevision(parseRevisions(document.updates ?? "[]"))?.date ?? fallback;
 
   const newest = (dates: string[]) => dates.reduce((a, b) => (a > b ? a : b));
+
+  /**
+   * A Part's or a Field Note's own date, revisions included — the same rule
+   * every other Post follows. Shared between the two rather than duplicated:
+   * both read the same two columns of the same table, only the Container
+   * differs.
+   *
+   * It is also what dates a Series landing above its Parts — the newest thing
+   * that happened to a Series is the newest thing that happened to one of its
+   * Parts. **Not** so for a Project: `SitemapProject`'s own doc explains why —
+   * a Project is revised in place and dated by its own revisions, not by what
+   * was written about it, so a note's date never reaches `/projects/<slug>`.
+   */
+  const containedPostLastmod = (post: SitemapContentItem) =>
+    revisedAt(post, post.publishedStringDate);
 
   // Dated by the most recently revised project, not by a clock and not by the
   // index page's own existence.
@@ -159,19 +182,17 @@ export function buildSitemapRoutes(
             changefreq: "monthly" as const,
             priority: 0.7,
           })),
+          ...notes.map((note) => ({
+            url: `/projects/${note.projectSlug}/${note.slug}`,
+            lastmod: containedPostLastmod(note),
+            changefreq: "monthly" as const,
+            priority: 0.7,
+          })),
         ]
       : [];
 
-  /**
-   * A Part's own date, revisions included — the same rule every other Post
-   * follows. It is also what dates the landing above it, because the newest
-   * thing that happened to a Series is the newest thing that happened to one of
-   * its Parts.
-   */
-  const partLastmod = (part: SitemapContentItem) => revisedAt(part, part.publishedStringDate);
-
   const seriesLastmod = (slug: string) => {
-    const dates = parts.filter((part) => part.seriesSlug === slug).map(partLastmod);
+    const dates = parts.filter((part) => part.seriesSlug === slug).map(containedPostLastmod);
 
     // A Series exists the moment it is announced — the arc is the point, not
     // the word count — so a landing with nothing published behind it is an
@@ -196,7 +217,7 @@ export function buildSitemapRoutes(
           })),
           ...parts.map((part) => ({
             url: `/series/${part.seriesSlug}/${part.slug}`,
-            lastmod: partLastmod(part),
+            lastmod: containedPostLastmod(part),
             changefreq: "monthly" as const,
             priority: 0.7,
           })),

--- a/seed/verify-stores.ts
+++ b/seed/verify-stores.ts
@@ -81,7 +81,8 @@ function d1Query<T>(sql: string, wranglerArgs: string[]): T[] {
  *
  * The rule mirrors `generate-seed-sql.ts` exactly, including what it skips: a
  * Post whose filename carries no Locale is not seeded, so it is not expected
- * here either. `…​.en-old.md` is one such file.
+ * here either — `…​.en-old.md` is one such file — and neither is any document
+ * declaring `draft: true`, whatever its type.
  */
 async function expectedFromMarkdown(): Promise<Expectation> {
     const expectation: Expectation = {
@@ -122,11 +123,21 @@ async function expectedFromMarkdown(): Promise<Expectation> {
                 type?: string;
                 tags?: unknown;
                 sections?: Array<{ slug: string }>;
+                draft?: unknown;
             }>(await fsPromise.readFile(full, "utf-8"));
 
+            // `draft: true` produces no row, of any type — mirrored leniently:
+            // this script's job is comparing what publishes against what is
+            // stored, not re-validating that the flag is a boolean, which the
+            // build already refuses to seed from if it is not.
+            if (attributes.draft === true) {
+                continue;
+            }
+
             if (attributes.type === "post") {
-                // A Post with no Locale in its filename is a draft: no row, and
-                // so no Tag rows either. The rule is the generator's, mirrored.
+                // A Post with no Locale in its filename is a draft under the
+                // `.en-old.md` convention: no row, and so no Tag rows either.
+                // The rule is the generator's, mirrored.
                 if (locale) {
                     expectation.content.add(`${slug}:${locale}`);
                     addTags(slug, locale, attributes.tags);

--- a/tests/integration/content-routes.test.ts
+++ b/tests/integration/content-routes.test.ts
@@ -93,9 +93,12 @@ describe("/ — the landing page", () => {
 });
 
 /**
- * `/blog` changed unit: loose Posts plus each Series as a single entry. A Part
- * appearing here individually would mean publishing part nine lengthens the
- * page, which is exactly what the change exists to prevent.
+ * `/blog` changed unit: loose Posts plus each Container — Series or Project —
+ * as a single entry. A Part or a Field Note appearing here individually would
+ * mean publishing part nine, or a new note, lengthens the page, which is
+ * exactly what the change exists to prevent. The fixtures carry no published
+ * Field Note (`field-notes.test.ts` covers a Project that has one), so this
+ * file only asserts a loose Post has no Container at all.
  */
 describe("/blog", () => {
   const load = () => blogLoader(routeArgs<ArgsOf<typeof blogLoader>>(platform, get("/blog")));
@@ -110,15 +113,18 @@ describe("/blog", () => {
       if (entry.kind === "post") {
         expect(entry.post.type).toBe("post");
         expect(entry.post.seriesSlug).toBeNull();
+        expect(entry.post.projectSlug).toBeNull();
       }
     }
   });
 
-  it("orders both units by date, newest first — a Series by its most recent Part", async () => {
+  it("orders every unit by date, newest first — a Container by its most recent child", async () => {
     const { entries } = await load();
-    const dates = entries.map((entry) =>
-      entry.kind === "post" ? entry.post.publishedAt : entry.series.publishedAt,
-    );
+    const dates = entries.map((entry) => {
+      if (entry.kind === "post") return entry.post.publishedAt;
+      if (entry.kind === "series") return entry.series.publishedAt;
+      return entry.project.publishedAt;
+    });
 
     expect(dates.every(Boolean)).toBe(true);
     expect(dates).toEqual([...dates].sort().reverse());

--- a/tests/integration/field-notes.test.ts
+++ b/tests/integration/field-notes.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { loader as blogSlugLoader } from "~/routes/blog-slug/_$blog-slug";
+import { loader as projectNoteLoader } from "~/routes/project-note/_$project-note";
+
+import { findLoosePosts } from "~/models/content.server";
+
+import { kvKeyFor } from "../../seed/kv/kv-keys";
+import { openTestPlatform, routeArgs, type TestPlatform } from "../setup/platform";
+
+/**
+ * No Field Note is published in the fixtures — the first one, Chekalo's
+ * product matching, enters as a Draft (`evolution-plan/14-phase-1b-field-notes.md`
+ * Part 13), so `seed/d1/seed.sql` seeds none. The tests below insert a
+ * Content Item row and its `blog:` payload directly, the way `content.test.ts`
+ * already inserts rows to exercise a constraint, and remove them again in
+ * `afterAll` — the test state directory is shared for the whole run, and a
+ * leftover row would move the counts `content.test.ts` and `series.test.ts`
+ * assert.
+ */
+
+const NOTE_SLUG = "test-field-note";
+const PROJECT_SLUG = "chekalo";
+
+let platform: TestPlatform;
+
+type ArgsOf<Loader> = Loader extends (args: infer A) => unknown ? A : never;
+
+const get = (path: string) => new Request(`https://poschuler.com${path}`);
+
+beforeAll(async () => {
+  platform = await openTestPlatform();
+
+  await platform.env.POSCHULER_BD.prepare(
+    `insert into content
+      (slug, lang, type, title, description, published_at, project_slug, section_order, container_order)
+      values (?, 'en', 'post', 'A Field Note for testing', 'About something.', '2026-08-01', ?, 0, 0)`,
+  )
+    .bind(NOTE_SLUG, PROJECT_SLUG)
+    .run();
+
+  const key = kvKeyFor(`blog/${NOTE_SLUG}.en.json`);
+
+  if (!key) {
+    throw new Error(`could not derive a KV key for ${NOTE_SLUG}`);
+  }
+
+  await platform.env.BLOG_KV.put(
+    key,
+    JSON.stringify({
+      attributes: {
+        title: "A Field Note for testing",
+        description: "About something.",
+        publishedAt: "2026-08-01",
+        tags: ["nodejs"],
+      },
+      html: "<p>Body.</p>",
+    }),
+  );
+});
+
+afterAll(async () => {
+  await platform.env.POSCHULER_BD.prepare("delete from content where slug = ? and lang = 'en'")
+    .bind(NOTE_SLUG)
+    .run();
+
+  const key = kvKeyFor(`blog/${NOTE_SLUG}.en.json`);
+
+  if (key) {
+    await platform.env.BLOG_KV.delete(key);
+  }
+
+  await platform?.dispose();
+});
+
+describe("findLoosePosts — excludes a Field Note", () => {
+  it("excludes a Post whose Container is a Project, the same as one whose Container is a Series", async () => {
+    const loose = await findLoosePosts(platform.env.POSCHULER_BD);
+
+    expect(loose.some((post) => post.slug === NOTE_SLUG)).toBe(false);
+  });
+});
+
+describe("/projects/:projectSlug/:noteSlug — a Field Note", () => {
+  const args = (project: string, note: string) =>
+    routeArgs<ArgsOf<typeof projectNoteLoader>>(platform, get(`/projects/${project}/${note}`), {
+      projectSlug: project,
+      noteSlug: note,
+    });
+
+  it("resolves a published note, with the Project named above its title", async () => {
+    const payload = await projectNoteLoader(args(PROJECT_SLUG, NOTE_SLUG));
+
+    expect(payload.title).toBe("A Field Note for testing");
+    expect(payload.projectSlug).toBe(PROJECT_SLUG);
+    expect(payload.projectTitle).toBeTruthy();
+    expect(payload.html).toContain("<");
+  });
+
+  it("404s on a Slug with nothing behind it", async () => {
+    await expect(projectNoteLoader(args(PROJECT_SLUG, "no-such-note"))).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  /**
+   * A Draft produces no row at all (Part 3 of the field notes), so it reads
+   * exactly like an unknown Slug from this route's point of view — there is
+   * nothing in D1 to distinguish "never written" from "written, not yet
+   * published".
+   */
+  it("404s on a note that is a Draft, the same way it 404s on an unknown one", async () => {
+    await expect(
+      projectNoteLoader(args(PROJECT_SLUG, "an-unpublished-draft")),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  /**
+   * The Project decides. A Slug some other Project's manifest lists is a 404
+   * rather than an article inside somebody else's frame — the same rule
+   * `/series/:seriesSlug/:partSlug` already applies to a Part.
+   */
+  it("404s on a note that belongs to a different Project", async () => {
+    await expect(
+      projectNoteLoader(args("poschuler-com", NOTE_SLUG)),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("404s on a Project that does not exist", async () => {
+    await expect(
+      projectNoteLoader(args("no-such-project", NOTE_SLUG)),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+/**
+ * A Field Note's payload sits under the same `blog:` key as any other Post —
+ * the prefix says what kind of payload it is, not which URL serves it — so KV
+ * alone would answer `/blog/:slug` with a page that also exists under
+ * `/projects/…`. One article at two addresses is a canonical nobody declared.
+ */
+describe("/blog/:blogSlug — sends a Field Note to its Project", () => {
+  it("redirects rather than serving it a second time", async () => {
+    const args = routeArgs<ArgsOf<typeof blogSlugLoader>>(platform, get(`/blog/${NOTE_SLUG}`), {
+      blogSlug: NOTE_SLUG,
+    });
+
+    const response: Response = await blogSlugLoader(args).then(
+      () => {
+        throw new Error(`/blog/${NOTE_SLUG} served a Field Note instead of redirecting`);
+      },
+      (thrown) => thrown,
+    );
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe(`/projects/${PROJECT_SLUG}/${NOTE_SLUG}`);
+  });
+});

--- a/tests/integration/field-notes.test.ts
+++ b/tests/integration/field-notes.test.ts
@@ -2,8 +2,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { loader as blogSlugLoader } from "~/routes/blog-slug/_$blog-slug";
 import { loader as projectNoteLoader } from "~/routes/project-note/_$project-note";
+import { loader as projectLandingLoader } from "~/routes/project-slug/_$project-slug";
 
 import { findLoosePosts } from "~/models/content.server";
+import { findProjectNotes } from "~/models/project.server";
 
 import { kvKeyFor } from "../../seed/kv/kv-keys";
 import { openTestPlatform, routeArgs, type TestPlatform } from "../setup/platform";
@@ -11,15 +13,20 @@ import { openTestPlatform, routeArgs, type TestPlatform } from "../setup/platfor
 /**
  * No Field Note is published in the fixtures — the first one, Chekalo's
  * product matching, enters as a Draft (`evolution-plan/14-phase-1b-field-notes.md`
- * Part 13), so `seed/d1/seed.sql` seeds none. The tests below insert a
- * Content Item row and its `blog:` payload directly, the way `content.test.ts`
+ * Part 13), so `seed/d1/seed.sql` seeds none. The tests below insert Content
+ * Item rows and their `blog:` payloads directly, the way `content.test.ts`
  * already inserts rows to exercise a constraint, and remove them again in
  * `afterAll` — the test state directory is shared for the whole run, and a
  * leftover row would move the counts `content.test.ts` and `series.test.ts`
  * assert.
+ *
+ * Two notes, not one: the landing's index and a note's sibling list both need
+ * a manifest with more than one entry to prove they order it rather than just
+ * showing whatever they are handed.
  */
 
 const NOTE_SLUG = "test-field-note";
+const NOTE_SLUG_2 = "test-field-note-two";
 const PROJECT_SLUG = "chekalo";
 
 let platform: TestPlatform;
@@ -28,47 +35,69 @@ type ArgsOf<Loader> = Loader extends (args: infer A) => unknown ? A : never;
 
 const get = (path: string) => new Request(`https://poschuler.com${path}`);
 
-beforeAll(async () => {
-  platform = await openTestPlatform();
-
+async function insertNote(
+  slug: string,
+  {
+    title,
+    summary,
+    order,
+    projectSlug = PROJECT_SLUG,
+  }: { title: string; summary: string; order: number; projectSlug?: string },
+) {
   await platform.env.POSCHULER_BD.prepare(
     `insert into content
       (slug, lang, type, title, description, published_at, project_slug, section_order, container_order)
-      values (?, 'en', 'post', 'A Field Note for testing', 'About something.', '2026-08-01', ?, 0, 0)`,
+      values (?, 'en', 'post', ?, ?, ?, ?, ?, ?)`,
   )
-    .bind(NOTE_SLUG, PROJECT_SLUG)
+    .bind(slug, title, summary, `2026-08-0${order + 1}`, projectSlug, order, order)
     .run();
 
-  const key = kvKeyFor(`blog/${NOTE_SLUG}.en.json`);
+  const key = kvKeyFor(`blog/${slug}.en.json`);
 
   if (!key) {
-    throw new Error(`could not derive a KV key for ${NOTE_SLUG}`);
+    throw new Error(`could not derive a KV key for ${slug}`);
   }
 
   await platform.env.BLOG_KV.put(
     key,
     JSON.stringify({
       attributes: {
-        title: "A Field Note for testing",
-        description: "About something.",
-        publishedAt: "2026-08-01",
+        title,
+        description: summary,
+        publishedAt: `2026-08-0${order + 1}`,
         tags: ["nodejs"],
       },
       html: "<p>Body.</p>",
     }),
   );
-});
+}
 
-afterAll(async () => {
+async function deleteNote(slug: string) {
   await platform.env.POSCHULER_BD.prepare("delete from content where slug = ? and lang = 'en'")
-    .bind(NOTE_SLUG)
+    .bind(slug)
     .run();
 
-  const key = kvKeyFor(`blog/${NOTE_SLUG}.en.json`);
+  const key = kvKeyFor(`blog/${slug}.en.json`);
 
   if (key) {
     await platform.env.BLOG_KV.delete(key);
   }
+}
+
+beforeAll(async () => {
+  platform = await openTestPlatform();
+
+  await insertNote(NOTE_SLUG, { title: "A Field Note for testing", summary: "About something.", order: 0 });
+  await insertNote(NOTE_SLUG_2, {
+    title: "A second Field Note for testing",
+    summary: "About something else.",
+    order: 1,
+  });
+});
+
+afterAll(async () => {
+  await deleteNote(NOTE_SLUG);
+  await deleteNote(NOTE_SLUG_2);
 
   await platform?.dispose();
 });
@@ -78,6 +107,51 @@ describe("findLoosePosts — excludes a Field Note", () => {
     const loose = await findLoosePosts(platform.env.POSCHULER_BD);
 
     expect(loose.some((post) => post.slug === NOTE_SLUG)).toBe(false);
+  });
+});
+
+/**
+ * The read the landing's index and a note's sibling list share (Part 11 of
+ * `evolution-plan/14-phase-1b-field-notes.md`).
+ */
+describe("findProjectNotes", () => {
+  it("returns a Project's published notes in manifest order, each with its summary", async () => {
+    const notes = await findProjectNotes(platform.env.POSCHULER_BD, PROJECT_SLUG);
+    const slugs = notes.map((note) => note.slug);
+
+    expect(slugs.indexOf(NOTE_SLUG)).toBeGreaterThanOrEqual(0);
+    expect(slugs.indexOf(NOTE_SLUG)).toBeLessThan(slugs.indexOf(NOTE_SLUG_2));
+    expect(notes.find((note) => note.slug === NOTE_SLUG)?.summary).toBe("About something.");
+  });
+
+  it("returns nothing for a Project with no published notes", async () => {
+    expect(await findProjectNotes(platform.env.POSCHULER_BD, "poschuler-com")).toEqual([]);
+  });
+});
+
+describe("/projects/:project — the notes index", () => {
+  const args = (project: string) =>
+    routeArgs<ArgsOf<typeof projectLandingLoader>>(platform, get(`/projects/${project}`), {
+      projectSlug: project,
+    });
+
+  it("lists its published notes in manifest order, each with its summary", async () => {
+    const payload = await projectLandingLoader(args(PROJECT_SLUG));
+    const slugs = payload.notes.map((note) => note.slug);
+
+    expect(slugs).toContain(NOTE_SLUG);
+    expect(slugs).toContain(NOTE_SLUG_2);
+    expect(slugs.indexOf(NOTE_SLUG)).toBeLessThan(slugs.indexOf(NOTE_SLUG_2));
+    expect(payload.notes.find((note) => note.slug === NOTE_SLUG)?.summary).toBe(
+      "About something.",
+    );
+  });
+
+  /** The index has nothing to render — the block is absent, not empty. */
+  it("holds no notes for a Project that has published none", async () => {
+    const payload = await projectLandingLoader(args("poschuler-com"));
+
+    expect(payload.notes).toEqual([]);
   });
 });
 
@@ -95,6 +169,19 @@ describe("/projects/:projectSlug/:noteSlug — a Field Note", () => {
     expect(payload.projectSlug).toBe(PROJECT_SLUG);
     expect(payload.projectTitle).toBeTruthy();
     expect(payload.html).toContain("<");
+  });
+
+  /**
+   * The sibling list at the foot: the Project's other published notes, this
+   * one's own Slug still in the set the loader hands the route — `NoteSiblings`
+   * is what filters it out, so this is what it filters (Part 11).
+   */
+  it("hands the route every published note of the Project, siblings included", async () => {
+    const payload = await projectNoteLoader(args(PROJECT_SLUG, NOTE_SLUG));
+    const slugs = payload.notes.map((note) => note.slug);
+
+    expect(slugs).toContain(NOTE_SLUG);
+    expect(slugs).toContain(NOTE_SLUG_2);
   });
 
   it("404s on a Slug with nothing behind it", async () => {
@@ -130,6 +217,40 @@ describe("/projects/:projectSlug/:noteSlug — a Field Note", () => {
     await expect(
       projectNoteLoader(args("no-such-project", NOTE_SLUG)),
     ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+/**
+ * The Project this note belongs to holds no other published note, so
+ * `NoteSiblings` (`project-note/orientation.tsx`) has nothing to list — its
+ * own manifest of one. A separate Project and note, isolated with its own
+ * setup and teardown, because `PROJECT_SLUG` above deliberately carries two.
+ */
+describe("/projects/:project/:note — a lone published note", () => {
+  const LONE_PROJECT_SLUG = "pragmatic-nodejs-api";
+  const LONE_NOTE_SLUG = "test-lone-field-note";
+
+  beforeAll(() =>
+    insertNote(LONE_NOTE_SLUG, {
+      title: "The only Field Note here",
+      summary: "About the only thing.",
+      order: 0,
+      projectSlug: LONE_PROJECT_SLUG,
+    }),
+  );
+
+  afterAll(() => deleteNote(LONE_NOTE_SLUG));
+
+  it("hands the route exactly one note — itself, with no sibling", async () => {
+    const payload = await projectNoteLoader(
+      routeArgs<ArgsOf<typeof projectNoteLoader>>(
+        platform,
+        get(`/projects/${LONE_PROJECT_SLUG}/${LONE_NOTE_SLUG}`),
+        { projectSlug: LONE_PROJECT_SLUG, noteSlug: LONE_NOTE_SLUG },
+      ),
+    );
+
+    expect(payload.notes.map((note) => note.slug)).toEqual([LONE_NOTE_SLUG]);
   });
 });
 

--- a/tests/integration/field-notes.test.ts
+++ b/tests/integration/field-notes.test.ts
@@ -1,11 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { loader as blogLoader } from "~/routes/blog/_blog";
 import { loader as blogSlugLoader } from "~/routes/blog-slug/_$blog-slug";
 import { loader as projectNoteLoader } from "~/routes/project-note/_$project-note";
 import { loader as projectLandingLoader } from "~/routes/project-slug/_$project-slug";
 
 import { findLoosePosts } from "~/models/content.server";
-import { findProjectNotes } from "~/models/project.server";
+import { findProjectNotes, findProjectsWithNotes } from "~/models/project.server";
 
 import { kvKeyFor } from "../../seed/kv/kv-keys";
 import { openTestPlatform, routeArgs, type TestPlatform } from "../setup/platform";
@@ -126,6 +127,72 @@ describe("findProjectNotes", () => {
 
   it("returns nothing for a Project with no published notes", async () => {
     expect(await findProjectNotes(platform.env.POSCHULER_BD, "poschuler-com")).toEqual([]);
+  });
+});
+
+/**
+ * The read `/blog` needs to list a Project with Field Notes as a single entry
+ * (Part 10 of `evolution-plan/14-phase-1b-field-notes.md`).
+ */
+describe("findProjectsWithNotes", () => {
+  it("returns a Project with at least one published note, dated by the most recent", async () => {
+    const projects = await findProjectsWithNotes(platform.env.POSCHULER_BD);
+    const chekalo = projects.find((project) => project.slug === PROJECT_SLUG);
+
+    expect(chekalo?.publishedStringDate).toBe("2026-08-02");
+  });
+
+  it("omits a Project with no published notes", async () => {
+    const projects = await findProjectsWithNotes(platform.env.POSCHULER_BD);
+
+    expect(projects.some((project) => project.slug === "poschuler-com")).toBe(false);
+  });
+});
+
+/**
+ * `/blog` changes unit: a Project with Field Notes appears as one entry, not
+ * one per note (1b/6, Part 10).
+ */
+describe("/blog — a Project with Field Notes is one entry", () => {
+  const load = () => blogLoader(routeArgs<ArgsOf<typeof blogLoader>>(platform, get("/blog")));
+
+  it("appears exactly once, dated by its most recent note", async () => {
+    const { entries } = await load();
+    const projectEntries = entries.filter(
+      (entry) => entry.kind === "project" && entry.project.slug === PROJECT_SLUG,
+    );
+
+    expect(projectEntries).toHaveLength(1);
+    expect(
+      projectEntries[0]!.kind === "project" && projectEntries[0]!.project.publishedStringDate,
+    ).toBe("2026-08-02");
+  });
+
+  it("does not list either of its notes individually", async () => {
+    const { entries } = await load();
+    const postSlugs = entries
+      .filter((entry) => entry.kind === "post")
+      .map((entry) => entry.kind === "post" && entry.post.slug);
+
+    expect(postSlugs).not.toContain(NOTE_SLUG);
+    expect(postSlugs).not.toContain(NOTE_SLUG_2);
+  });
+
+  it("links to the Project landing", async () => {
+    const { entries } = await load();
+    const projectEntry = entries.find(
+      (entry) => entry.kind === "project" && entry.project.slug === PROJECT_SLUG,
+    );
+
+    expect(projectEntry?.kind === "project" && projectEntry.project.slug).toBe(PROJECT_SLUG);
+  });
+
+  it("leaves out a Project with no published notes", async () => {
+    const { entries } = await load();
+
+    expect(
+      entries.some((entry) => entry.kind === "project" && entry.project.slug === "poschuler-com"),
+    ).toBe(false);
   });
 });
 

--- a/tests/unit/app/hrefs.test.ts
+++ b/tests/unit/app/hrefs.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { postHref, seriesHref, tagHref } from "../../../app/lib/hrefs";
+import { postHref, projectHref, seriesHref, tagHref } from "../../../app/lib/hrefs";
 
 /**
  * Four lines with a test, because the rule they hold is the one that used to
  * live inline in `ContentItem` as `/blog/${item.slug}` — and the day a Part
  * moved under its Series, that line started producing a 404 from every list on
- * the site at once.
+ * the site at once. 1b (`evolution-plan/14-phase-1b-field-notes.md`) adds the
+ * third branch: a Field Note under its Project.
  */
 
 describe("postHref", () => {
@@ -21,11 +22,41 @@ describe("postHref", () => {
       "/series/pragmatic-nodejs-api/project-setup",
     );
   });
+
+  it("serves a Field Note under its Project", () => {
+    expect(
+      postHref({ slug: "product-matching", seriesSlug: null, projectSlug: "chekalo" }),
+    ).toBe("/projects/chekalo/product-matching");
+  });
+
+  /**
+   * The two Container columns never both hold a value (`schema.sql`), so this
+   * case never arises in practice — what it pins is that the function still
+   * resolves to exactly one branch rather than to neither or to both.
+   */
+  it("resolves to the Series when handed both, rather than to neither", () => {
+    expect(
+      postHref({ slug: "x", seriesSlug: "pragmatic-nodejs-api", projectSlug: "chekalo" }),
+    ).toBe("/series/pragmatic-nodejs-api/x");
+  });
+
+  /** Callers outside a Project's own note listing never pass `projectSlug` at all. */
+  it("treats an absent projectSlug the same as null", () => {
+    expect(postHref({ slug: "project-setup", seriesSlug: "pragmatic-nodejs-api" })).toBe(
+      postHref({ slug: "project-setup", seriesSlug: "pragmatic-nodejs-api", projectSlug: null }),
+    );
+  });
 });
 
 describe("seriesHref", () => {
   it("points at the landing", () => {
     expect(seriesHref("pragmatic-nodejs-api")).toBe("/series/pragmatic-nodejs-api");
+  });
+});
+
+describe("projectHref", () => {
+  it("points at the landing", () => {
+    expect(projectHref("chekalo")).toBe("/projects/chekalo");
   });
 });
 

--- a/tests/unit/app/structured-data.test.ts
+++ b/tests/unit/app/structured-data.test.ts
@@ -6,6 +6,7 @@ import {
   breadcrumbList,
   creativeWorkSeries,
   HOME_CRUMB,
+  projectId,
   seriesId,
 } from "~/lib/seo/structured-data";
 
@@ -23,6 +24,14 @@ const PART = {
   description: "Where a Node.js project's structure comes from.",
   datePublished: "2025-12-25",
   seriesSlug: "pragmatic-nodejs-api",
+};
+
+const NOTE = {
+  path: "/projects/chekalo/product-matching",
+  title: "Matching products across retailers without a shared id",
+  description: "The problem, and the shape of the solution.",
+  datePublished: "2026-08-15",
+  projectSlug: "chekalo",
 };
 
 describe("blogPosting", () => {
@@ -79,6 +88,18 @@ describe("blogPosting", () => {
   it("says nothing about containment for a Post that has no Container", () => {
     expect(blogPosting({ ...PART, seriesSlug: null })).not.toHaveProperty("isPartOf");
     expect(blogPosting({ ...PART, seriesSlug: undefined })).not.toHaveProperty("isPartOf");
+  });
+
+  /** A Field Note's Container is a Project, not a Series (Part 11 of the field notes). */
+  it("attaches a Field Note to its Project by the identifier the landing declares", () => {
+    const article = blogPosting(NOTE);
+
+    expect(article.isPartOf).toEqual({ "@id": projectId("chekalo") });
+  });
+
+  it("says nothing about containment for a Field Note with no projectSlug given", () => {
+    expect(blogPosting({ ...NOTE, projectSlug: null })).not.toHaveProperty("isPartOf");
+    expect(blogPosting({ ...NOTE, projectSlug: undefined })).not.toHaveProperty("isPartOf");
   });
 });
 

--- a/tests/unit/seed/content-tree.test.ts
+++ b/tests/unit/seed/content-tree.test.ts
@@ -113,18 +113,28 @@ describe("placementOf — content inside a Container", () => {
   });
 
   /**
-   * Field Notes are 1b, and they need a `project_slug` on `content` to be
-   * linkable. Accepting one today would seed a Post with no Container.
+   * 1b generalises the depth rule to `projects/`: depth 2 stays the Project
+   * itself, and depth 3 is a Field Note whose Container is the folder above —
+   * the same rule a Part already follows under `series/`.
    */
-  it("fails a Field Note under a Project, which arrives in 1b", () => {
-    const result = placementOf("projects/chekalo/a-field-note/a-field-note.en.md");
-
-    expect(isMisplaced(result)).toBe(true);
-    expect((result as { error: string }).error).toMatch(/nothing nests under projects/);
+  it("reads a Field Note as a Post whose Container is the Project above", () => {
+    expect(placement("projects/chekalo/product-matching/product-matching.en.md")).toEqual({
+      tree: "projects",
+      type: "post",
+      container: "chekalo",
+    });
   });
 
   it("fails anything nested deeper than a Container", () => {
     const result = placementOf("series/api/part-one/deeper/deeper.en.md");
+
+    expect(isMisplaced(result)).toBe(true);
+    expect((result as { error: string }).error).toMatch(/deeper than a Container/);
+  });
+
+  /** The same rule, the same message, on the other tree that holds a Container. */
+  it("fails a Field Note nested deeper than its Project", () => {
+    const result = placementOf("projects/chekalo/product-matching/deeper/deeper.en.md");
 
     expect(isMisplaced(result)).toBe(true);
     expect((result as { error: string }).error).toMatch(/deeper than a Container/);
@@ -168,6 +178,7 @@ describe("declaredTypeMatches", () => {
     ["project", "projects/a/a.en.md"],
     ["series", "series/a/a.en.md"],
     ["post", "series/a/part/part.en.md"],
+    ["post", "projects/a/note/note.en.md"],
   ])("accepts type %s at %s", (type, relativePath) => {
     expect(declaredTypeMatches(type, placement(relativePath))).toBe(true);
   });

--- a/tests/unit/seed/project-sql.test.ts
+++ b/tests/unit/seed/project-sql.test.ts
@@ -1,17 +1,27 @@
 import { describe, expect, it } from "vitest";
 
-import { isInvalid, isSkipped, type SeededRow } from "../../../seed/d1/seed-sql";
+import type { SeededRow } from "../../../seed/d1/seed-sql";
 import {
   buildProjectSeedSql,
+  isInvalidProject,
   projectRowFor,
   type ProjectFrontMatter,
+  type ProjectNoteFile,
+  type ProjectRows,
 } from "../../../seed/d1/project-sql";
 
 /**
  * A Project is not a Content Item — no Published At, no place in the Timeline —
  * so it has its own table and its own rules. What it shares with `content` is
  * the shape of the seed: upserts first, prune last, never a leading delete.
+ *
+ * 1b adds the manifest: which Field Notes a Project holds, and in what order
+ * (Part 8 of `evolution-plan/14-phase-1b-field-notes.md`) — a flat list, not
+ * an arc, reconciled against the notes on disk the same way a Series' Parts
+ * are (`manifest.ts`, shared rather than copied).
  */
+
+const MANIFEST = "projects/chekalo/chekalo.en.md";
 
 const project = (overrides: Partial<ProjectFrontMatter> = {}): ProjectFrontMatter => ({
   type: "project",
@@ -27,9 +37,42 @@ const project = (overrides: Partial<ProjectFrontMatter> = {}): ProjectFrontMatte
   ...overrides,
 });
 
+const noteFile = (slug: string, overrides: Partial<ProjectNoteFile> = {}): ProjectNoteFile => ({
+  slug,
+  lang: "en",
+  folder: slug,
+  relativePath: `projects/chekalo/${slug}/${slug}.en.md`,
+  draft: false,
+  ...overrides,
+});
+
+const rowsFor = (
+  attributes: ProjectFrontMatter = project(),
+  noteFiles: ProjectNoteFile[] = [],
+): ProjectRows => {
+  const result = projectRowFor(MANIFEST, attributes, noteFiles);
+
+  if (isInvalidProject(result)) {
+    throw new Error(`expected rows, got: ${result.error}`);
+  }
+
+  return result;
+};
+
+const errorFor = (
+  attributes: ProjectFrontMatter,
+  noteFiles: ProjectNoteFile[] = [],
+): string => {
+  const result = projectRowFor(MANIFEST, attributes, noteFiles);
+
+  expect(isInvalidProject(result)).toBe(true);
+
+  return (result as { error: string }).error;
+};
+
 describe("projectRowFor", () => {
   it("emits an upsert keyed by (Slug, Locale), with the slug from the filename", () => {
-    const row = projectRowFor("projects/chekalo/chekalo.en.md", project()) as SeededRow;
+    const { project: row } = rowsFor();
 
     expect(row.key).toBe("chekalo:en");
     expect(row.statement).toContain("INSERT OR REPLACE INTO project");
@@ -37,21 +80,15 @@ describe("projectRowFor", () => {
   });
 
   it("serialises the stack as JSON and an absent one as an empty array", () => {
-    const withStack = projectRowFor("projects/a/a.en.md", project()) as SeededRow;
-    const without = projectRowFor(
-      "projects/a/a.en.md",
-      project({ stack: undefined }),
-    ) as SeededRow;
+    const withStack = rowsFor().project;
+    const without = rowsFor(project({ stack: undefined })).project;
 
     expect(withStack.statement).toContain(`'["TypeScript","Node.js"]'`);
     expect(without.statement).toContain(`'[]'`);
   });
 
   it("defaults sort_order rather than letting it be null", () => {
-    const row = projectRowFor(
-      "projects/a/a.en.md",
-      project({ sortOrder: undefined }),
-    ) as SeededRow;
+    const row = rowsFor(project({ sortOrder: undefined })).project;
 
     expect(row.statement).toMatch(/, 0,/);
   });
@@ -62,16 +99,13 @@ describe("projectRowFor", () => {
    * to the generic date for the whole site.
    */
   it("fails a Project with no revisions at all", () => {
-    const result = projectRowFor("projects/a/a.en.md", project({ updates: [] }));
-
-    expect(isInvalid(result)).toBe(true);
-    expect((result as { error: string }).error).toMatch(/at least one/);
+    expect(errorFor(project({ updates: [] }))).toMatch(/at least one/);
   });
 
   it("fails a Project whose language is not in its filename", () => {
-    const result = projectRowFor("projects/a/a.md", project());
+    const result = projectRowFor("projects/a/a.md", project(), []);
 
-    expect(isSkipped(result) || isInvalid(result)).toBe(true);
+    expect(isInvalidProject(result)).toBe(true);
   });
 
   it.each([
@@ -79,10 +113,7 @@ describe("projectRowFor", () => {
     ["status", { status: "live" as never }, /status/],
     ["summary", { summary: "  " }, /summary/],
   ])("fails an unusable %s", (_field, overrides, message) => {
-    const result = projectRowFor("projects/a/a.en.md", project(overrides));
-
-    expect(isInvalid(result)).toBe(true);
-    expect((result as { error: string }).error).toMatch(message);
+    expect(errorFor(project(overrides))).toMatch(message);
   });
 
   /**
@@ -91,134 +122,196 @@ describe("projectRowFor", () => {
    * recreating the table by hand in production.
    */
   it("accepts experiment, which the schema allows before anything uses it", () => {
-    const result = projectRowFor("projects/a/a.en.md", project({ tier: "experiment" }));
+    const result = projectRowFor(MANIFEST, project({ tier: "experiment" }), []);
 
-    expect(isInvalid(result)).toBe(false);
+    expect(isInvalidProject(result)).toBe(false);
   });
 
   it("fails a file handed to it from outside the projects tree", () => {
-    const result = projectRowFor("blog/a/a.en.md", project());
+    const result = projectRowFor("blog/a/a.en.md", project(), []);
 
-    expect(isInvalid(result)).toBe(true);
+    expect(isInvalidProject(result)).toBe(true);
   });
 });
 
-/** A Project landing can be a Draft exactly like a Post can. */
-describe("projectRowFor — Drafts", () => {
-  it("skips a Project landing declaring itself a draft, after every other check has passed", () => {
-    const result = projectRowFor("projects/chekalo/chekalo.en.md", project({ draft: true }));
-
-    expect(isSkipped(result)).toBe(true);
-    expect((result as { reason: string }).reason).toBe("projects/chekalo/chekalo.en.md is a draft");
+/**
+ * The manifest declares which Field Notes the Project holds, and in what
+ * order — a flat list, not an arc: no sections, no Destination, nothing that
+ * checks contiguity (Part 8).
+ */
+describe("projectRowFor — the notes", () => {
+  it("has no notes when the manifest declares none, which is a Project's state before its first one", () => {
+    expect(rowsFor().notes.size).toBe(0);
   });
 
-  it("still fails a draft Project for every reason a published one would", () => {
-    const result = projectRowFor(
-      "projects/chekalo/chekalo.en.md",
-      project({ draft: true, tier: "featured" as never }),
+  it("reads a note's position out of the list", () => {
+    const attributes = project({ notes: ["product-matching", "alias-flip"] });
+    const files = [noteFile("product-matching"), noteFile("alias-flip")];
+
+    const { notes } = rowsFor(attributes, files);
+
+    expect(notes.get("product-matching")).toEqual({ projectSlug: "chekalo", order: 0 });
+    expect(notes.get("alias-flip")).toEqual({ projectSlug: "chekalo", order: 1 });
+  });
+
+  /** Reordering is a line moved in one file, the same property a Series has. */
+  it("renumbers every note when the list is reordered, with nothing else edited", () => {
+    const attributes = project({ notes: ["alias-flip", "product-matching"] });
+    const files = [noteFile("product-matching"), noteFile("alias-flip")];
+
+    const { notes } = rowsFor(attributes, files);
+
+    expect(notes.get("alias-flip")?.order).toBe(0);
+    expect(notes.get("product-matching")?.order).toBe(1);
+  });
+
+  it("fails a notes list that is not a list", () => {
+    expect(errorFor(project({ notes: "product-matching" as never }))).toMatch(
+      /not a list/,
     );
-
-    expect(isInvalid(result)).toBe(true);
   });
 
-  it("fails a non-boolean draft value rather than reading it as truthy", () => {
-    const result = projectRowFor("projects/chekalo/chekalo.en.md", project({ draft: "true" as never }));
-
-    expect(isInvalid(result)).toBe(true);
-    expect((result as { error: string }).error).toMatch(/draft must be true or false/);
-  });
-
-  it("behaves exactly as today when the flag is absent", () => {
-    const result = projectRowFor("projects/chekalo/chekalo.en.md", project());
-
-    expect(isSkipped(result)).toBe(false);
-    expect(isInvalid(result)).toBe(false);
+  it("fails a manifest listing an empty Field Note", () => {
+    expect(errorFor(project({ notes: [""] }))).toMatch(/lists an empty Field Note/);
   });
 
   /**
-   * The round trip: the existing prune removes what the walk no longer hands
-   * it. A second, always-published Project keeps the row list non-empty
-   * throughout — `buildProjectSeedSql([])` is deliberately a no-op (see its
-   * own tests below), so a lone Project's own draft round trip has to be
-   * proven with company, the way the site is never down to zero Projects.
+   * A note listed in the manifest while it is a Draft is accepted, and does
+   * not break reconciliation: `reconcileManifest` does not distinguish a
+   * Draft file from a published one, so a Project with published notes can
+   * list a Draft alongside them and still hold its position (Part 9).
+   */
+  it("accepts a note listed in the manifest while it is a Draft, without breaking reconciliation", () => {
+    const attributes = project({ notes: ["product-matching", "alias-flip"] });
+    const files = [noteFile("product-matching"), noteFile("alias-flip", { draft: true })];
+
+    const { notes } = rowsFor(attributes, files);
+
+    expect(notes.get("alias-flip")).toEqual({ projectSlug: "chekalo", order: 1 });
+  });
+});
+
+/**
+ * The invariant `manifest.ts` shares with `series-sql.ts`: a listed note with
+ * no file fails, a file no manifest lists fails, and a note listed twice fails.
+ */
+describe("projectRowFor — manifest and disk must reconcile", () => {
+  it("fails a listed note with no file", () => {
+    expect(errorFor(project({ notes: ["product-matching"] }), [])).toMatch(
+      /lists the Field Note 'product-matching', which has no file/,
+    );
+  });
+
+  it("fails a file no manifest lists", () => {
+    expect(errorFor(project(), [noteFile("product-matching")])).toMatch(
+      /product-matching.en.md is not listed/,
+    );
+  });
+
+  it("fails a note listed twice", () => {
+    const attributes = project({ notes: ["product-matching", "product-matching"] });
+
+    expect(errorFor(attributes, [noteFile("product-matching")])).toMatch(
+      /lists the Field Note 'product-matching' twice/,
+    );
+  });
+
+  /** Everything downstream builds the path back from the Slug. */
+  it("fails a note whose filename and folder disagree", () => {
+    const attributes = project({ notes: ["renamed"] });
+    const files = [{ ...noteFile("renamed"), folder: "product-matching" }];
+
+    expect(errorFor(attributes, files)).toMatch(/is not named after its folder/);
+  });
+});
+
+/**
+ * `draft: true` on a Project landing. Part 5's rule is stricter here than on a
+ * Post — a Container may be a Draft only while it holds no published content.
+ */
+describe("projectRowFor — Drafts", () => {
+  it("marks the result a draft when every listed note is a draft too, after every other check has passed", () => {
+    const attributes = project({ draft: true, notes: ["product-matching"] });
+    const files = [noteFile("product-matching", { draft: true })];
+
+    const { draft, project: row, notes } = rowsFor(attributes, files);
+
+    expect(draft).toBe(true);
+    // Still built, so a caller needing the placements has them — see
+    // `generate-seed-sql.ts`. Whether to seed `project` is the caller's
+    // decision, driven by `draft`.
+    expect(row.statement).toContain("INSERT OR REPLACE INTO project");
+    expect(notes.get("product-matching")).toEqual({ projectSlug: "chekalo", order: 0 });
+  });
+
+  it("marks the result published when the flag is absent, exactly as today", () => {
+    expect(rowsFor().draft).toBe(false);
+  });
+
+  /** A Draft passes every check a published one would. */
+  it("still fails a draft Project for every reason a published one would", () => {
+    expect(errorFor(project({ draft: true, tier: "featured" as never }))).toMatch(/tier/);
+  });
+
+  it("fails a non-boolean draft value rather than reading it as truthy", () => {
+    expect(errorFor(project({ draft: "true" as never }))).toMatch(/draft must be true or false/);
+  });
+
+  /**
+   * The rule this ticket adds: no cascade. A drafted Container does not hide
+   * its published children, it refuses to coexist with them, and the message
+   * names both.
+   */
+  it("fails a Project marked draft while one of its notes is published, naming the Container and the child", () => {
+    const attributes = project({ draft: true, notes: ["product-matching", "alias-flip"] });
+    const files = [
+      noteFile("product-matching", { draft: false }),
+      noteFile("alias-flip", { draft: true }),
+    ];
+
+    expect(errorFor(attributes, files)).toBe(
+      `${MANIFEST} is a draft, but 'product-matching' is published — a Post cannot be reached through a Container that is not.`,
+    );
+  });
+
+  it("passes when a drafted Project has no notes at all yet", () => {
+    expect(rowsFor(project({ draft: true }), []).draft).toBe(true);
+  });
+
+  /**
+   * The round trip: publishing inserted this Project's row through
+   * `buildProjectSeedSql`'s upsert; marking it a draft removes it from the
+   * rows the generator hands that function, so the existing prune deletes it.
    */
   it("removes a previously published Project's row through the existing prune once it becomes a draft", () => {
-    const chekalo = projectRowFor("projects/chekalo/chekalo.en.md", project()) as SeededRow;
+    const chekalo = rowsFor().project;
     const other = projectRowFor(
       "projects/poschuler-com/poschuler-com.en.md",
       project({ sortOrder: 2 }),
-    ) as SeededRow;
+      [],
+    ) as ProjectRows;
 
-    const sqlWhilePublished = buildProjectSeedSql([chekalo, other]);
+    const sqlWhilePublished = buildProjectSeedSql([chekalo, other.project]);
     expect(sqlWhilePublished).toContain(
       "DELETE FROM project WHERE slug || ':' || lang NOT IN ('chekalo:en', 'poschuler-com:en')",
     );
 
-    const draftResult = projectRowFor("projects/chekalo/chekalo.en.md", project({ draft: true }));
-    expect(isSkipped(draftResult)).toBe(true);
+    const draftResult = rowsFor(project({ draft: true }));
+    expect(draftResult.draft).toBe(true);
 
-    // The generator's walk now hands only `other` to the builder — the same
-    // keep-list mechanism, with chekalo's key excluded.
-    const sqlAfterDraft = buildProjectSeedSql([other]);
+    // The generator's walk now hands only `other`'s row to the builder — the
+    // same keep-list mechanism, with chekalo's key excluded.
+    const sqlAfterDraft = buildProjectSeedSql([other.project]);
     expect(sqlAfterDraft).toContain("DELETE FROM project WHERE slug || ':' || lang NOT IN ('poschuler-com:en')");
-  });
-
-  /**
-   * `preview:drafts` (Part 3 of the field notes) — see the matching block in
-   * `seed-sql.test.ts` for the reasoning.
-   */
-  describe("includeDrafts", () => {
-    it("emits a row for a draft Project instead of skipping it", () => {
-      const result = projectRowFor(
-        "projects/chekalo/chekalo.en.md",
-        project({ draft: true }),
-        { includeDrafts: true },
-      );
-
-      expect(isSkipped(result)).toBe(false);
-      expect(isInvalid(result)).toBe(false);
-      expect((result as SeededRow).key).toBe("chekalo:en");
-    });
-
-    it("still skips a draft Project when the option is false", () => {
-      const result = projectRowFor(
-        "projects/chekalo/chekalo.en.md",
-        project({ draft: true }),
-        { includeDrafts: false },
-      );
-
-      expect(isSkipped(result)).toBe(true);
-    });
-
-    it("still fails a draft Project for every reason a published one would, drafts included", () => {
-      const result = projectRowFor(
-        "projects/chekalo/chekalo.en.md",
-        project({ draft: true, tier: "featured" as never }),
-        { includeDrafts: true },
-      );
-
-      expect(isInvalid(result)).toBe(true);
-    });
-
-    it("does not affect a published Project — the same row either way", () => {
-      const withoutOption = projectRowFor("projects/chekalo/chekalo.en.md", project());
-      const withOption = projectRowFor(
-        "projects/chekalo/chekalo.en.md",
-        project(),
-        { includeDrafts: true },
-      );
-
-      expect((withoutOption as SeededRow).statement).toBe((withOption as SeededRow).statement);
-    });
   });
 });
 
 describe("buildProjectSeedSql", () => {
-  const rows = () =>
-    [
-      projectRowFor("projects/chekalo/chekalo.en.md", project()) as SeededRow,
-      projectRowFor("projects/poschuler-com/poschuler-com.en.md", project()) as SeededRow,
-    ] satisfies SeededRow[];
+  const rows = (): SeededRow[] => [
+    rowsFor().project,
+    (projectRowFor("projects/poschuler-com/poschuler-com.en.md", project(), []) as ProjectRows)
+      .project,
+  ];
 
   it("puts every insert before the prune", () => {
     const sql = buildProjectSeedSql(rows());

--- a/tests/unit/seed/project-sql.test.ts
+++ b/tests/unit/seed/project-sql.test.ts
@@ -162,6 +162,55 @@ describe("projectRowFor — Drafts", () => {
     const sqlAfterDraft = buildProjectSeedSql([other]);
     expect(sqlAfterDraft).toContain("DELETE FROM project WHERE slug || ':' || lang NOT IN ('poschuler-com:en')");
   });
+
+  /**
+   * `preview:drafts` (Part 3 of the field notes) — see the matching block in
+   * `seed-sql.test.ts` for the reasoning.
+   */
+  describe("includeDrafts", () => {
+    it("emits a row for a draft Project instead of skipping it", () => {
+      const result = projectRowFor(
+        "projects/chekalo/chekalo.en.md",
+        project({ draft: true }),
+        { includeDrafts: true },
+      );
+
+      expect(isSkipped(result)).toBe(false);
+      expect(isInvalid(result)).toBe(false);
+      expect((result as SeededRow).key).toBe("chekalo:en");
+    });
+
+    it("still skips a draft Project when the option is false", () => {
+      const result = projectRowFor(
+        "projects/chekalo/chekalo.en.md",
+        project({ draft: true }),
+        { includeDrafts: false },
+      );
+
+      expect(isSkipped(result)).toBe(true);
+    });
+
+    it("still fails a draft Project for every reason a published one would, drafts included", () => {
+      const result = projectRowFor(
+        "projects/chekalo/chekalo.en.md",
+        project({ draft: true, tier: "featured" as never }),
+        { includeDrafts: true },
+      );
+
+      expect(isInvalid(result)).toBe(true);
+    });
+
+    it("does not affect a published Project — the same row either way", () => {
+      const withoutOption = projectRowFor("projects/chekalo/chekalo.en.md", project());
+      const withOption = projectRowFor(
+        "projects/chekalo/chekalo.en.md",
+        project(),
+        { includeDrafts: true },
+      );
+
+      expect((withoutOption as SeededRow).statement).toBe((withOption as SeededRow).statement);
+    });
+  });
 });
 
 describe("buildProjectSeedSql", () => {

--- a/tests/unit/seed/project-sql.test.ts
+++ b/tests/unit/seed/project-sql.test.ts
@@ -103,6 +103,67 @@ describe("projectRowFor", () => {
   });
 });
 
+/** A Project landing can be a Draft exactly like a Post can. */
+describe("projectRowFor — Drafts", () => {
+  it("skips a Project landing declaring itself a draft, after every other check has passed", () => {
+    const result = projectRowFor("projects/chekalo/chekalo.en.md", project({ draft: true }));
+
+    expect(isSkipped(result)).toBe(true);
+    expect((result as { reason: string }).reason).toBe("projects/chekalo/chekalo.en.md is a draft");
+  });
+
+  it("still fails a draft Project for every reason a published one would", () => {
+    const result = projectRowFor(
+      "projects/chekalo/chekalo.en.md",
+      project({ draft: true, tier: "featured" as never }),
+    );
+
+    expect(isInvalid(result)).toBe(true);
+  });
+
+  it("fails a non-boolean draft value rather than reading it as truthy", () => {
+    const result = projectRowFor("projects/chekalo/chekalo.en.md", project({ draft: "true" as never }));
+
+    expect(isInvalid(result)).toBe(true);
+    expect((result as { error: string }).error).toMatch(/draft must be true or false/);
+  });
+
+  it("behaves exactly as today when the flag is absent", () => {
+    const result = projectRowFor("projects/chekalo/chekalo.en.md", project());
+
+    expect(isSkipped(result)).toBe(false);
+    expect(isInvalid(result)).toBe(false);
+  });
+
+  /**
+   * The round trip: the existing prune removes what the walk no longer hands
+   * it. A second, always-published Project keeps the row list non-empty
+   * throughout — `buildProjectSeedSql([])` is deliberately a no-op (see its
+   * own tests below), so a lone Project's own draft round trip has to be
+   * proven with company, the way the site is never down to zero Projects.
+   */
+  it("removes a previously published Project's row through the existing prune once it becomes a draft", () => {
+    const chekalo = projectRowFor("projects/chekalo/chekalo.en.md", project()) as SeededRow;
+    const other = projectRowFor(
+      "projects/poschuler-com/poschuler-com.en.md",
+      project({ sortOrder: 2 }),
+    ) as SeededRow;
+
+    const sqlWhilePublished = buildProjectSeedSql([chekalo, other]);
+    expect(sqlWhilePublished).toContain(
+      "DELETE FROM project WHERE slug || ':' || lang NOT IN ('chekalo:en', 'poschuler-com:en')",
+    );
+
+    const draftResult = projectRowFor("projects/chekalo/chekalo.en.md", project({ draft: true }));
+    expect(isSkipped(draftResult)).toBe(true);
+
+    // The generator's walk now hands only `other` to the builder — the same
+    // keep-list mechanism, with chekalo's key excluded.
+    const sqlAfterDraft = buildProjectSeedSql([other]);
+    expect(sqlAfterDraft).toContain("DELETE FROM project WHERE slug || ':' || lang NOT IN ('poschuler-com:en')");
+  });
+});
+
 describe("buildProjectSeedSql", () => {
   const rows = () =>
     [
@@ -131,5 +192,17 @@ describe("buildProjectSeedSql", () => {
    */
   it("emits nothing at all when there are no projects", () => {
     expect(buildProjectSeedSql([])).toBe("");
+  });
+
+  /**
+   * The bug an empty list alone cannot rule out: the site's one Project going
+   * draft looks identical, from `rows.length`, to no Project ever having been
+   * written — unless the caller says otherwise. Without `anyFilesFound`, this
+   * would leave a previously published Project's row live in D1 forever.
+   */
+  it("prunes everything when every Project the walk found is a draft", () => {
+    const sql = buildProjectSeedSql([], { anyFilesFound: true });
+
+    expect(sql).toContain("DELETE FROM project WHERE slug || ':' || lang NOT IN ()");
   });
 });

--- a/tests/unit/seed/seed-sql.test.ts
+++ b/tests/unit/seed/seed-sql.test.ts
@@ -135,7 +135,7 @@ describe("contentRowFor — Posts", () => {
       VOCABULARY,
     ) as SeededRow;
 
-    expect(row.statement).toContain("(slug, lang, type, title, description, published_at, tags, repository, updates, series_slug, series_section, section_order, updated_at)");
+    expect(row.statement).toContain("(slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)");
     expect(row.statement).not.toContain("external_url");
   });
 
@@ -153,16 +153,6 @@ describe("contentRowFor — Posts", () => {
     ) as SeededRow;
 
     expect(row.statement).toContain("'[]', NULL, NULL, NULL, CURRENT_TIMESTAMP)");
-  });
-
-  it("serialises absent tags as an empty JSON array, not as NULL", () => {
-    const row = contentRowFor(
-      "blog/x/x.en.md",
-      post({ tags: undefined }),
-      VOCABULARY,
-    ) as SeededRow;
-
-    expect(row.statement).toContain(`'[]'`);
   });
 
   /**
@@ -198,7 +188,7 @@ describe("contentRowFor — Bookmarks", () => {
   it("carries the Source and external URL a Bookmark has", () => {
     const row = contentRowFor("bookmarks/a.md", bookmark(), VOCABULARY) as SeededRow;
 
-    expect(row.statement).toContain("(slug, lang, type, title, external_url, source, published_at, tags, updated_at)");
+    expect(row.statement).toContain("(slug, lang, type, title, external_url, source, published_at, updated_at)");
     expect(row.statement).toContain("'https://example.com/a', 'Example'");
   });
 });
@@ -342,7 +332,13 @@ describe("contentRowFor — Tags are drawn from the declared vocabulary", () => 
     );
 
     expect(isInvalid(result)).toBe(false);
-    expect((result as SeededRow).statement).toContain(`'["nodejs","software-architecture"]'`);
+    // Against the rows, because the rows are where a declared Tag now lands.
+    // This used to read the JSON copy on `content`, which said the same thing
+    // about a column nothing queried.
+    expect((result as ContentRow).tags.map((tag) => tag.key)).toEqual([
+      "a:en:nodejs",
+      "a:en:software-architecture",
+    ]);
   });
 
   /**

--- a/tests/unit/seed/seed-sql.test.ts
+++ b/tests/unit/seed/seed-sql.test.ts
@@ -289,6 +289,78 @@ describe("contentRowFor — Drafts", () => {
     const sqlAfterDraft = buildSeedSql([]);
     expect(sqlAfterDraft).toContain("DELETE FROM content WHERE slug || ':' || ifnull(lang, '') NOT IN ()");
   });
+
+  /**
+   * `preview:drafts` (Part 3 of the field notes) — a Draft read as though it
+   * were published, so it can be seeded into the local stores without ever
+   * touching a tracked file. Both switch values are covered here, at the
+   * generator seam; the script's own wiring is verified by running it.
+   */
+  describe("includeDrafts", () => {
+    it("emits a row for a draft Post instead of skipping it", () => {
+      const result = contentRowFor(
+        "blog/a/a.en.md",
+        post({ draft: true }),
+        VOCABULARY,
+        undefined,
+        { includeDrafts: true },
+      );
+
+      expect(isSkipped(result)).toBe(false);
+      expect(isInvalid(result)).toBe(false);
+      expect((result as ContentRow).key).toBe("a:en");
+    });
+
+    it("emits a row for a draft Bookmark instead of skipping it", () => {
+      const result = contentRowFor(
+        "bookmarks/a.md",
+        bookmark({ draft: true }),
+        VOCABULARY,
+        undefined,
+        { includeDrafts: true },
+      );
+
+      expect(isSkipped(result)).toBe(false);
+      expect((result as ContentRow).key).toBe("a:");
+    });
+
+    it("still skips a draft Post when the option is false", () => {
+      const result = contentRowFor(
+        "blog/a/a.en.md",
+        post({ draft: true }),
+        VOCABULARY,
+        undefined,
+        { includeDrafts: false },
+      );
+
+      expect(isSkipped(result)).toBe(true);
+    });
+
+    it("still fails a draft Post for every reason a published one would, drafts included", () => {
+      const result = contentRowFor(
+        "blog/a/a.en.md",
+        post({ draft: true, tags: ["not-a-declared-tag"] }),
+        VOCABULARY,
+        undefined,
+        { includeDrafts: true },
+      );
+
+      expect(isInvalid(result)).toBe(true);
+    });
+
+    it("does not affect a published Post — the same row either way", () => {
+      const withoutOption = contentRowFor("blog/a/a.en.md", post(), VOCABULARY);
+      const withOption = contentRowFor(
+        "blog/a/a.en.md",
+        post(),
+        VOCABULARY,
+        undefined,
+        { includeDrafts: true },
+      );
+
+      expect((withoutOption as ContentRow).statement).toBe((withOption as ContentRow).statement);
+    });
+  });
 });
 
 describe("contentRowFor — Bookmarks", () => {

--- a/tests/unit/seed/seed-sql.test.ts
+++ b/tests/unit/seed/seed-sql.test.ts
@@ -135,15 +135,15 @@ describe("contentRowFor — Posts", () => {
       VOCABULARY,
     ) as SeededRow;
 
-    expect(row.statement).toContain("(slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)");
+    expect(row.statement).toContain("(slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, project_slug, section_order, container_order, updated_at)");
     expect(row.statement).not.toContain("external_url");
   });
 
   /**
    * The Container columns travel together or not at all, which is why nothing
-   * checks that they do: a loose Post is written with four NULLs rather than
-   * with the columns omitted, so a Post that leaves a Series cannot keep half
-   * of one.
+   * checks that they do: a loose Post is written with five NULLs rather than
+   * with the columns omitted, so a Post that leaves a Series or a Project
+   * cannot keep half of one.
    */
   it("writes a loose Post with no Container rather than with none of the columns", () => {
     const row = contentRowFor(
@@ -152,7 +152,7 @@ describe("contentRowFor — Posts", () => {
       VOCABULARY,
     ) as SeededRow;
 
-    expect(row.statement).toContain("'[]', NULL, NULL, NULL, NULL, CURRENT_TIMESTAMP)");
+    expect(row.statement).toContain("'[]', NULL, NULL, NULL, NULL, NULL, CURRENT_TIMESTAMP)");
   });
 
   /**
@@ -396,7 +396,7 @@ describe("contentRowFor — Parts of a Series", () => {
     const row = contentRowFor(partPath, post(), VOCABULARY, placement) as SeededRow;
 
     expect(row.key).toBe("project-setup:en");
-    expect(row.statement).toContain("'pragmatic-nodejs-api', 'fundamentals', 1, 1, CURRENT_TIMESTAMP)");
+    expect(row.statement).toContain("'pragmatic-nodejs-api', 'fundamentals', NULL, 1, 1, CURRENT_TIMESTAMP)");
   });
 
   /** Zero is a position, and a falsy one. It must survive the round trip. */
@@ -406,7 +406,7 @@ describe("contentRowFor — Parts of a Series", () => {
       order: 0,
     }) as SeededRow;
 
-    expect(row.statement).toContain("'fundamentals', 0, 0, CURRENT_TIMESTAMP)");
+    expect(row.statement).toContain("'fundamentals', NULL, 0, 0, CURRENT_TIMESTAMP)");
   });
 
   /**
@@ -422,7 +422,7 @@ describe("contentRowFor — Parts of a Series", () => {
       order: 3,
     }) as SeededRow;
 
-    expect(row.statement).toContain("'fundamentals', 3, 3, CURRENT_TIMESTAMP)");
+    expect(row.statement).toContain("'fundamentals', NULL, 3, 3, CURRENT_TIMESTAMP)");
   });
 
   /**
@@ -469,6 +469,63 @@ describe("contentRowFor — Parts of a Series", () => {
       post(),
       VOCABULARY,
     );
+
+    expect(isInvalid(result)).toBe(true);
+    expect((result as { error: string }).error).toMatch(/does not belong in the content table/);
+  });
+});
+
+/**
+ * A Field Note is a Post whose Container is a Project — `PartPlacement`'s
+ * sibling, `NotePlacement`, written from the Project manifest's flat list
+ * rather than from an arc (Part 2 and Part 6 of the field notes).
+ */
+describe("contentRowFor — Field Notes of a Project", () => {
+  const notePath = "projects/chekalo/product-matching/product-matching.en.md";
+  const placement = { projectSlug: "chekalo", order: 0 };
+
+  it("writes the Container the manifest supplies, with no Series columns", () => {
+    const row = contentRowFor(notePath, post(), VOCABULARY, placement) as SeededRow;
+
+    expect(row.key).toBe("product-matching:en");
+    expect(row.statement).toContain("NULL, NULL, 'chekalo', 0, 0, CURRENT_TIMESTAMP)");
+  });
+
+  /** Both order columns carry the same value, as a Part's do. */
+  it("writes both order columns with the same value", () => {
+    const row = contentRowFor(notePath, post(), VOCABULARY, {
+      ...placement,
+      order: 2,
+    }) as SeededRow;
+
+    expect(row.statement).toContain("'chekalo', 2, 2, CURRENT_TIMESTAMP)");
+  });
+
+  /**
+   * A note listed in the manifest while it is a Draft is accepted — the
+   * Container check above already passed, because reconciliation does not
+   * distinguish a Draft file from a published one (Part 9 of the field
+   * notes) — and only then does it produce nothing.
+   */
+  it("skips a draft Field Note that is listed in its manifest, after the Container check passes", () => {
+    const result = contentRowFor(notePath, post({ draft: true }), VOCABULARY, placement);
+
+    expect(isSkipped(result)).toBe(true);
+  });
+
+  /**
+   * The other half of *manifest and disk reconcile*: a note nothing indexes
+   * would be seeded with no Container, so no listing could link to it.
+   */
+  it("fails a Field Note its manifest does not list", () => {
+    const result = contentRowFor(notePath, post(), VOCABULARY);
+
+    expect(isInvalid(result)).toBe(true);
+    expect((result as { error: string }).error).toMatch(/not listed in the chekalo manifest/);
+  });
+
+  it("fails a Project handed to the content generator", () => {
+    const result = contentRowFor("projects/chekalo/chekalo.en.md", post(), VOCABULARY);
 
     expect(isInvalid(result)).toBe(true);
     expect((result as { error: string }).error).toMatch(/does not belong in the content table/);

--- a/tests/unit/seed/seed-sql.test.ts
+++ b/tests/unit/seed/seed-sql.test.ts
@@ -135,13 +135,13 @@ describe("contentRowFor — Posts", () => {
       VOCABULARY,
     ) as SeededRow;
 
-    expect(row.statement).toContain("(slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, updated_at)");
+    expect(row.statement).toContain("(slug, lang, type, title, description, published_at, repository, updates, series_slug, series_section, section_order, container_order, updated_at)");
     expect(row.statement).not.toContain("external_url");
   });
 
   /**
    * The Container columns travel together or not at all, which is why nothing
-   * checks that they do: a loose Post is written with three NULLs rather than
+   * checks that they do: a loose Post is written with four NULLs rather than
    * with the columns omitted, so a Post that leaves a Series cannot keep half
    * of one.
    */
@@ -152,7 +152,7 @@ describe("contentRowFor — Posts", () => {
       VOCABULARY,
     ) as SeededRow;
 
-    expect(row.statement).toContain("'[]', NULL, NULL, NULL, CURRENT_TIMESTAMP)");
+    expect(row.statement).toContain("'[]', NULL, NULL, NULL, NULL, CURRENT_TIMESTAMP)");
   });
 
   /**
@@ -206,7 +206,7 @@ describe("contentRowFor — Parts of a Series", () => {
     const row = contentRowFor(partPath, post(), VOCABULARY, placement) as SeededRow;
 
     expect(row.key).toBe("project-setup:en");
-    expect(row.statement).toContain("'pragmatic-nodejs-api', 'fundamentals', 1, CURRENT_TIMESTAMP)");
+    expect(row.statement).toContain("'pragmatic-nodejs-api', 'fundamentals', 1, 1, CURRENT_TIMESTAMP)");
   });
 
   /** Zero is a position, and a falsy one. It must survive the round trip. */
@@ -216,7 +216,23 @@ describe("contentRowFor — Parts of a Series", () => {
       order: 0,
     }) as SeededRow;
 
-    expect(row.statement).toContain("'fundamentals', 0, CURRENT_TIMESTAMP)");
+    expect(row.statement).toContain("'fundamentals', 0, 0, CURRENT_TIMESTAMP)");
+  });
+
+  /**
+   * `container_order` is what every query reads now; `section_order` stays
+   * only for the previously deployed Worker, still asking for it by that name
+   * during this publication's migrate-then-deploy window. Both have to carry
+   * the same position, or that Worker and the one about to replace it would
+   * disagree about where a Part sits.
+   */
+  it("writes both order columns with the same value", () => {
+    const row = contentRowFor(partPath, post(), VOCABULARY, {
+      ...placement,
+      order: 3,
+    }) as SeededRow;
+
+    expect(row.statement).toContain("'fundamentals', 3, 3, CURRENT_TIMESTAMP)");
   });
 
   /**

--- a/tests/unit/seed/seed-sql.test.ts
+++ b/tests/unit/seed/seed-sql.test.ts
@@ -173,6 +173,124 @@ describe("contentRowFor — Posts", () => {
   });
 });
 
+/**
+ * ADR 0009: `draft: true` in front matter. The file is read, classified and
+ * checked exactly like a published one, and only then produces nothing.
+ */
+describe("contentRowFor — Drafts", () => {
+  it("skips a Post declaring itself a draft, after every other check has passed", () => {
+    const result = contentRowFor("blog/a/a.en.md", post({ draft: true }), VOCABULARY);
+
+    expect(isSkipped(result)).toBe(true);
+    expect((result as { reason: string }).reason).toBe("blog/a/a.en.md is a draft");
+  });
+
+  /**
+   * Part 12's promise: a Draft passes every check a published document
+   * passes. An undeclared Tag still fails the build, draft or not.
+   */
+  it("still fails a draft Post for every reason a published one would", () => {
+    const result = contentRowFor(
+      "blog/a/a.en.md",
+      post({ draft: true, tags: ["not-a-declared-tag"] }),
+      VOCABULARY,
+    );
+
+    expect(isInvalid(result)).toBe(true);
+  });
+
+  it("fails a draft Part that is not listed in its manifest, exactly as a published one would", () => {
+    const result = contentRowFor(
+      "series/pragmatic-nodejs-api/project-setup/project-setup.en.md",
+      post({ draft: true }),
+      VOCABULARY,
+    );
+
+    expect(isInvalid(result)).toBe(true);
+    expect((result as { error: string }).error).toMatch(/not listed in the pragmatic-nodejs-api manifest/);
+  });
+
+  /**
+   * A Part that is listed and is a draft: every check a Part has to pass
+   * still runs, and only then does it produce nothing.
+   */
+  it("skips a draft Part that is listed in its manifest, after the Container check passes", () => {
+    const result = contentRowFor(
+      "series/pragmatic-nodejs-api/project-setup/project-setup.en.md",
+      post({ draft: true }),
+      VOCABULARY,
+      { seriesSlug: "pragmatic-nodejs-api", section: "fundamentals", order: 1 },
+    );
+
+    expect(isSkipped(result)).toBe(true);
+  });
+
+  /** JavaScript's own truthiness is not trusted for the flag. */
+  it.each([["true"], ["yes"], [1]])("fails a non-boolean draft value %j rather than reading it as truthy", (value) => {
+    const result = contentRowFor("blog/a/a.en.md", post({ draft: value as never }), VOCABULARY);
+
+    expect(isInvalid(result)).toBe(true);
+    expect((result as { error: string }).error).toMatch(/draft must be true or false/);
+  });
+
+  it("behaves exactly as today when the flag is absent", () => {
+    const result = contentRowFor("blog/a/a.en.md", post(), VOCABULARY);
+
+    expect(isSkipped(result)).toBe(false);
+    expect(isInvalid(result)).toBe(false);
+  });
+
+  it("skips a Bookmark declaring itself a draft, after every other check has passed", () => {
+    const result = contentRowFor("bookmarks/a.md", bookmark({ draft: true }), VOCABULARY);
+
+    expect(isSkipped(result)).toBe(true);
+    expect((result as { reason: string }).reason).toBe("bookmarks/a.md is a draft");
+  });
+
+  it("still fails a draft Bookmark for every reason a published one would", () => {
+    const result = contentRowFor(
+      "bookmarks/a.md",
+      bookmark({ draft: true, tags: ["not-a-declared-tag"] }),
+      VOCABULARY,
+    );
+
+    expect(isInvalid(result)).toBe(true);
+  });
+
+  it("fails a non-boolean draft value on a Bookmark", () => {
+    const result = contentRowFor("bookmarks/a.md", bookmark({ draft: "true" as never }), VOCABULARY);
+
+    expect(isInvalid(result)).toBe(true);
+    expect((result as { error: string }).error).toMatch(/draft must be true or false/);
+  });
+
+  /**
+   * The round trip (Part 12's last rule): publishing inserted this row
+   * through `buildSeedSql`'s upsert; marking the same file a draft removes
+   * it from the rows the generator hands that function, so the existing
+   * prune — `DELETE FROM content WHERE … NOT IN (keyList)` — deletes it. No
+   * new mechanism, the same one every removed file already goes through.
+   */
+  it("removes a previously published Post's row through the existing prune once it becomes a draft", () => {
+    const published = contentRowFor("blog/a/a.en.md", post(), VOCABULARY) as ContentRow;
+
+    expect(isSkipped(published)).toBe(false);
+
+    const sqlWhilePublished = buildSeedSql([published]);
+    expect(sqlWhilePublished).toContain("DELETE FROM content WHERE slug || ':' || ifnull(lang, '') NOT IN ('a:en')");
+
+    const draftResult = contentRowFor("blog/a/a.en.md", post({ draft: true }), VOCABULARY);
+    expect(isSkipped(draftResult)).toBe(true);
+
+    // The generator collects rows from every file it walks; a draft
+    // contributes none, so the row that survived above is gone from the list
+    // `buildSeedSql` prunes against — the same keep-list mechanism, now
+    // excluding it.
+    const sqlAfterDraft = buildSeedSql([]);
+    expect(sqlAfterDraft).toContain("DELETE FROM content WHERE slug || ':' || ifnull(lang, '') NOT IN ()");
+  });
+});
+
 describe("contentRowFor — Bookmarks", () => {
   it("emits an upsert keyed by Slug alone, with a null Locale", () => {
     const row = contentRowFor(

--- a/tests/unit/seed/series-sql.test.ts
+++ b/tests/unit/seed/series-sql.test.ts
@@ -39,11 +39,13 @@ const manifest = (overrides: Partial<SeriesFrontMatter> = {}): SeriesFrontMatter
   ...overrides,
 });
 
-const partFile = (slug: string): SeriesPartFile => ({
+const partFile = (slug: string, overrides: Partial<SeriesPartFile> = {}): SeriesPartFile => ({
   slug,
   lang: "en",
   folder: slug,
   relativePath: `series/api/${slug}/${slug}.en.md`,
+  draft: false,
+  ...overrides,
 });
 
 const FILES = [partFile("project-setup"), partFile("error-handling")];
@@ -310,12 +312,121 @@ describe("seriesRowsFor — the path decides what the file is", () => {
     expect(isInvalidSeries(result)).toBe(true);
   });
 
-  /** A landing has no draft state: it is one page, revised in place. */
+  /**
+   * A landing has no `.en-old.md` convention to hide behind, as a Post does:
+   * it is one page, revised in place, so a missing Locale is a mistake.
+   * `draft: true` is the only way one goes unpublished — see below.
+   */
   it("fails a manifest with no Locale in its filename", () => {
     const result = seriesRowsFor("series/api/api.md", manifest(), BODY, FILES);
 
     expect(isInvalidSeries(result)).toBe(true);
     expect((result as { error: string }).error).toMatch(/must have a language/);
+  });
+});
+
+/**
+ * `draft: true` on a Series manifest. Part 5's rule is stricter here
+ * than on a Post — a Container may be a Draft only while it holds no
+ * published content, checked below.
+ */
+describe("seriesRowsFor — Drafts", () => {
+  it("marks the result a draft when every listed Part is a draft too, after every other check has passed", () => {
+    const files = [
+      partFile("project-setup", { draft: true }),
+      partFile("error-handling", { draft: true }),
+    ];
+
+    const { draft, series, sections } = rowsFor(manifest({ draft: true }), files);
+
+    expect(draft).toBe(true);
+    // Still built, so a caller needing the placements has them — see
+    // `generate-seed-sql.ts`. Whether to seed `series`/`sections` is the
+    // caller's decision, driven by `draft`.
+    expect(series.statement).toContain("INSERT OR REPLACE INTO series");
+    expect(sections).toHaveLength(2);
+  });
+
+  it("marks the result published when the flag is absent, exactly as today", () => {
+    expect(rowsFor().draft).toBe(false);
+  });
+
+  /** Part 12's promise: a Draft passes every check a published one would. */
+  it("still fails a draft manifest for every reason a published one would", () => {
+    expect(errorFor(manifest({ draft: true, startingPoint: "  " }))).toMatch(/has no startingPoint/);
+  });
+
+  it("fails a non-boolean draft value rather than reading it as truthy", () => {
+    expect(errorFor(manifest({ draft: "true" as never }))).toMatch(/draft must be true or false/);
+  });
+
+  /**
+   * The rule this ticket adds: no cascade. A drafted Container does not hide
+   * its published children, it refuses to coexist with them, and the message
+   * names both.
+   */
+  it("fails a Series marked draft while one of its Parts is published, naming the Container and the child", () => {
+    const files = [
+      partFile("project-setup", { draft: false }),
+      partFile("error-handling", { draft: true }),
+    ];
+
+    const error = errorFor(manifest({ draft: true }), files);
+
+    expect(error).toBe(
+      `${MANIFEST} is a draft, but 'project-setup' is published — a Post cannot be reached through a Container that is not.`,
+    );
+  });
+
+  it("passes when a drafted Series has no Parts at all yet", () => {
+    const attributes = manifest({
+      draft: true,
+      sections: [{ slug: "fundamentals", title: "Fundamentals", summary: "Where the code goes." }],
+    });
+
+    expect(rowsFor(attributes, []).draft).toBe(true);
+  });
+
+  /**
+   * The round trip (Part 12's last rule): publishing inserted this Series's
+   * rows through `buildSeriesSeedSql`'s upsert; marking it a draft removes it
+   * from the rows the generator hands that function, so the existing prune —
+   * `DELETE FROM series WHERE … NOT IN (keyList)` — deletes it. A second,
+   * always-published Series keeps the row list non-empty throughout, the way
+   * `buildSeriesSeedSql([], [])` is deliberately a no-op for the day nothing
+   * has ever been written (see its own tests below).
+   */
+  it("removes a previously published Series's rows through the existing prune once it becomes a draft", () => {
+    const otherFiles = [
+      partFile("project-setup", { relativePath: "series/other/project-setup/project-setup.en.md" }),
+      partFile("error-handling", { relativePath: "series/other/error-handling/error-handling.en.md" }),
+    ];
+    const otherResult = seriesRowsFor("series/other/other.en.md", manifest(), BODY, otherFiles);
+
+    if (isInvalidSeries(otherResult)) {
+      throw new Error(`expected rows, got: ${otherResult.error}`);
+    }
+
+    const api = rowsFor();
+
+    const sqlWhilePublished = buildSeriesSeedSql([api.series, otherResult.series], [
+      ...api.sections,
+      ...otherResult.sections,
+    ]);
+    expect(sqlWhilePublished).toContain(
+      "DELETE FROM series WHERE slug || ':' || lang NOT IN ('api:en', 'other:en')",
+    );
+
+    const draftResult = rowsFor(
+      manifest({ draft: true }),
+      [partFile("project-setup", { draft: true }), partFile("error-handling", { draft: true })],
+    );
+    expect(draftResult.draft).toBe(true);
+
+    // The generator's walk now hands only `other`'s rows to the builder — the
+    // same keep-list mechanism, with the drafted manifest's key excluded.
+    const sqlAfterDraft = buildSeriesSeedSql([otherResult.series], otherResult.sections);
+    expect(sqlAfterDraft).toContain("DELETE FROM series WHERE slug || ':' || lang NOT IN ('other:en')");
   });
 });
 
@@ -354,5 +465,18 @@ describe("buildSeriesSeedSql", () => {
    */
   it("emits nothing at all when there are no Series", () => {
     expect(buildSeriesSeedSql([], [] as SeededRow[])).toBe("");
+  });
+
+  /**
+   * The bug an empty list alone cannot rule out: the site's one Series going
+   * draft looks identical, from `seriesRows.length`, to no Series ever having
+   * been written — unless the caller says otherwise. Without `anyFilesFound`,
+   * this would leave a previously published Series's rows live in D1 forever.
+   */
+  it("prunes everything when every Series the walk found is a draft", () => {
+    const sql = buildSeriesSeedSql([], [] as SeededRow[], { anyFilesFound: true });
+
+    expect(sql).toContain("DELETE FROM series WHERE slug || ':' || lang NOT IN ()");
+    expect(sql).toContain("DELETE FROM series_section WHERE series_slug || ':' || lang || ':' || slug NOT IN ()");
   });
 });

--- a/tests/unit/seed/sitemap-routes.test.ts
+++ b/tests/unit/seed/sitemap-routes.test.ts
@@ -53,6 +53,13 @@ const part = (
   publishedStringDate: string,
 ): SitemapContentItem => ({ slug, type: "post", publishedStringDate, seriesSlug });
 
+/** A Field Note: a Post whose Container is a Project rather than a Series. */
+const note = (
+  slug: string,
+  projectSlug: string,
+  publishedStringDate: string,
+): SitemapContentItem => ({ slug, type: "post", publishedStringDate, projectSlug });
+
 /** `updates` arrives as the stored JSON string, the form the column holds. */
 const project = (slug: string, ...dates: string[]): SitemapProject => ({
   slug,
@@ -281,6 +288,66 @@ describe("a Series in the sitemap", () => {
 
     expect(urls).not.toContain("/series");
     expect(urls.some((url) => url.startsWith("/series/"))).toBe(false);
+  });
+});
+
+/**
+ * A Field Note is a Post whose Container is a Project (1b/7), served under it
+ * the same way a Part is served under its Series. A Draft never reaches this
+ * seam at all — it produces no `content` row, so there is nothing here to
+ * filter; what these assert is that a published note gets a URL, and that
+ * nothing here invents one for a Slug that was never passed in.
+ */
+describe("a Field Note in the sitemap", () => {
+  const withNotes = [
+    note("product-matching", "chekalo", "2026-08-15"),
+    item("a-loose-post", "post", "2026-01-15"),
+  ];
+
+  const projects: SitemapProject[] = [project("chekalo", "2025-01-01")];
+
+  it("serves a published note under its Project, never under /blog", () => {
+    const urls = urlsOf(routesFor(withNotes, FALLBACK, RESUME_LASTMOD, projects));
+
+    expect(urls).toContain("/projects/chekalo/product-matching");
+    expect(urls).not.toContain("/blog/product-matching");
+    expect(urls).toContain("/blog/a-loose-post");
+  });
+
+  /**
+   * A Draft produces no `content` row, so it is never in `items` to begin
+   * with — the same reason it 404s at its own route. This is that absence,
+   * asserted the only way it can be from this seam: nothing but the one
+   * published note's own Slug appears under `/projects/chekalo/`.
+   */
+  it("advertises no address for a Draft, because a Draft is never in the list to begin with", () => {
+    const urls = urlsOf(routesFor(withNotes, FALLBACK, RESUME_LASTMOD, projects));
+    const chekaloUrls = urls.filter((url) => url.startsWith("/projects/chekalo/"));
+
+    expect(chekaloUrls).toEqual(["/projects/chekalo/product-matching"]);
+  });
+
+  it("dates a note by its latest revision, like any other Post", () => {
+    const revised: SitemapContentItem = {
+      ...note("product-matching", "chekalo", "2026-08-15"),
+      updates: JSON.stringify([{ date: "2026-09-01", note: "Clarified the diagram." }]),
+    };
+    const routes = routesFor([revised], FALLBACK, RESUME_LASTMOD, projects);
+
+    expect(routes.find((route) => route.url === "/projects/chekalo/product-matching")?.lastmod).toBe(
+      "2026-09-01",
+    );
+  });
+
+  /**
+   * Unlike a Series landing, a Project's own `lastmod` does not follow its
+   * notes — `SitemapProject`'s own doc explains why: a Project is revised in
+   * place, and its own revisions are the only date it has.
+   */
+  it("does not let a note's date move its Project's own landing", () => {
+    const routes = routesFor(withNotes, FALLBACK, RESUME_LASTMOD, projects);
+
+    expect(routes.find((route) => route.url === "/projects/chekalo")?.lastmod).toBe("2025-01-01");
   });
 });
 


### PR DESCRIPTION
Phase **1b** (Field Notes, and Drafts), plus the contract half of 2b's
expand-and-contract, which has been waiting on this publication. Merging this
runs the publish job, which is the only thing that deploys.

Spec: [#26](https://github.com/poschuler/poschuler.com/issues/26). Built from
`evolution-plan/14-phase-1b-field-notes.md`, in the ten-ticket chain
[#27](https://github.com/poschuler/poschuler.com/issues/27)–[#36](https://github.com/poschuler/poschuler.com/issues/36);
eight of them ship here.

## What ships

**A Field Note — a Post whose Container is a Project.** Depth three under
`projects/` classifies as a Post whose Container is the folder above (ADR 0004's
rule, generalised again). A Project declares the notes it holds in a manifest in
its own front matter, reconciled both ways like a Series' — but it declares a
**list**, not an arc: no Sections, no Destination, no contiguity check. A Series
orders because it promised a Destination; a Project accumulates because the
problems turn up when they turn up (ADR 0007, amended).

`/projects/:project/:note` serves the note with its Project named above the
title, the sibling notes and a link back to the Project at the foot, and no
previous/next — that would assert a path the Project never promised. The landing
gains its index of notes, each with its summary.

**`/blog` changes unit again**, and the rule loses an exception rather than
gaining one: it lists a Post with no Container, or a Container that holds Posts.
A Project with Field Notes is one entry dated by its most recent note; a Project
without them does not appear, which is why the page does not change until the
first note publishes.

**A Draft — a document the build validates and refuses to publish** (ADR 0009).
`draft: true` on any document in the content tree: classified, checked for
everything a published document is checked for, and then emitted nowhere — no
row, no payload, no sitemap entry, no listing, 404 at its address. Publishing is
deleting one line. A Container may be a Draft only while it holds no published
content; the contradiction fails the build rather than cascading, because a
document is invisible or it is finished and there is no third state.

It is **not** privacy. This repository is public and its history is permanent,
which is why the no-publish policy applies from the first keystroke and ADR 0009
says so.

**`pnpm preview:drafts`** renders Drafts into the local stores so one can be read
at its real address before publishing — same generators, two parameters, output
to an ignored directory. No tracked file moves, so nothing has to be reverted and
nothing can be committed by accident.

## The schema, and why this is the second of three steps

`0006` is additive: it adds `project_slug`, and adds `container_order` **beside**
`section_order` rather than renaming it. The generator writes both; the Worker
reads only the new one.

That is not caution for its own sake. The publish job applies migrations before
it deploys the Worker, so an atomic rename would leave the Worker still serving —
which reads `section_order` in the Series arc query — answering `no such column`
on the Series landing and every Part, through the seed, the build and the deploy.
Same hazard, same three steps as the JSON `tags` column.

**`0005` also ships here**, and it is the contract half of that earlier sequence:
the column is dropped now that the deployed Worker has stopped selecting it. Two
migrations, one additive and one contractive, and both are safe against the
Worker that serves while they run.

The contract half of *this* rename is
[#35](https://github.com/poschuler/poschuler.com/issues/35), which stays open and
blocked until this is live — on the **deployment**, not on this merge.

## Nothing visible changes for a reader yet

The first Field Note enters as a Draft
([#36](https://github.com/poschuler/poschuler.com/issues/36), Paul's to write),
so production gets the machinery and no notes. `/projects/chekalo` looks exactly
as it does today until that flag comes off. That is the sequencing decision the
phase was built on: the infrastructure lands first so that adding content later
is only adding content.

## Also here

`scripts/smoke-test.sh` stops gating the whole Project namespace on a published
note existing. `/projects` and a Project landing read both stores and depend on
no note, so they are probed always — and were never probed before this, not even
before 1b. Only the note route stays conditional.

## Verified on `dev`

| | |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm test` | 494 pass, 28 files (358 before the phase) |
| `pnpm run verify:schema:local` | the migration chain arrives at `schema.sql` |
| `pnpm run check:fixtures` | the committed fixtures are what the generators produce |
| `pnpm run smoke` | cold start, every route answers, now including `/projects` and a landing |

## Documentation

ADR 0009 (Drafts) is new; ADR 0007 is amended for the second Container.
`CONTEXT.md` gains **Field Note** and **Draft**, and **Container** stops saying
*today a Series, or none*. `README.md` and `docs/architecture.md` carry the
route, the columns and the preview command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
