### PR TITLE
ralph: #54, #55 — The verifier classifies by placement, in a tested pure module (+1 more)

### DIFF
--- a/ralph/RALPH.md
+++ b/ralph/RALPH.md
@@ -48,7 +48,8 @@ Configuration lives in [`ralph.config.sh`](./ralph.config.sh); the loop is in
   `prompts/*.md`, in git.
 - When the list drains, Ralph pushes and opens **one draft PR back to `dev`**,
   titled after the issues it worked (so it reads well even though the branch is a
-  timestamp).
+  timestamp). Its body carries **every advisory finding the run raised**, gathered
+  from the issues that raised them — see below.
 - **Ralph never merges.** Reviewing and merging is your job — the human gate.
 
 This fits the repo's branching model: `main` = production, `dev` = integration;
@@ -461,6 +462,19 @@ Command-line flags: `--dry-run`, `--max-iterations N`, `-h`/`--help`.
   the behaviour already lives. Refusing is the cheapest thing that session can
   do, and the counts are what stop "the review was wrong five times" from
   reaching you looking exactly like "this session did nothing".
+- **The advisory findings ride to the PR, because that is the only place you can
+  act on them.** They are the ones nobody touches by design — smells, scope
+  creep, a weak test — and their natural end was a comment on a *closed* issue,
+  which is the one place nobody goes back to. A finding like that is only ever
+  actionable with the diff in front of you, and there is exactly one moment when
+  that is true: reading the draft PR. So the PR body collects them all, each
+  linked to the review that raised it.
+  Two things follow. Reading them **together** is what a single issue's comment
+  cannot give you — one smell across three issues of a batch is not three notes,
+  it is a pattern, and probably a line in `AGENTS.md`. And nothing survives the
+  merge: what you don't act on there goes back to being findable only on a closed
+  issue, so open a ticket for what should outlive the PR and let the rest go on
+  purpose. Discarded is not the same as lost.
 - **A `ready-for-human` label on a CLOSED issue is a deferred finding.** When
   settling one needs a judgement only you can make, the fixer names the missing
   decision and labels the issue rather than guessing or burying it as a refusal.

--- a/ralph/ralph.sh
+++ b/ralph/ralph.sh
@@ -315,6 +315,50 @@ tally_field() {
   awk -v f="$2" '{print $f}' <<< "$1"
 }
 
+# issue_advisory <issue> — the review's `## Advisory` findings for this issue,
+# already shaped as a block for the PR body, or empty when there were none.
+#
+# Advisory findings are the ones nobody acts on by design — smells, scope creep,
+# a weak test — and until now they ended their life in a comment on a CLOSED
+# issue, which is the one place nobody goes back to. They are only ever
+# actionable with the diff in front of you, and there is exactly one moment when
+# that is true: reading the draft PR. So they travel there.
+#
+# Through the REST API rather than gh_read, for two reasons: it hands over the
+# comment's own URL as html_url, and on 17 Aug 2026 it kept answering through a
+# GraphQL outage that had `gh issue view --json` returning 503 on every retry.
+#
+# per_page rides in the query string, and it has to: `gh api -F per_page=100`
+# turns the call into a POST, which on this endpoint means *create a comment*.
+# It failed 422 for want of a body, which is the only reason a read here was
+# merely a read.
+#
+# A missing block is a poorer PR body, never a failed run — every path here
+# returns empty rather than failing.
+issue_advisory() {
+  local issue="$1" try raw url findings
+  for try in 1 2 3; do
+    raw="$(gh api "repos/{owner}/{repo}/issues/$issue/comments?per_page=100" \
+      --jq 'map(select(.body | test("(^|\n)[ \t]*RALPH-VERDICT:"))) | last | (.html_url + "\n" + .body)' \
+      2>/dev/null)" && [[ -n "$raw" ]] && break
+    raw=""
+    [[ "$try" -lt 3 ]] && sleep 2
+  done
+  [[ -n "$raw" ]] || return 0
+
+  url="$(head -1 <<< "$raw")"
+  # Everything under the Advisory heading, stopping at the verdict line that
+  # closes every report.
+  findings="$(awk 'NR==1{next}
+                   /^##[[:space:]]+Advisory/{f=1; next}
+                   f && /^[[:space:]]*RALPH-VERDICT:/{f=0}
+                   f && /^##[[:space:]]/{f=0}
+                   f' <<< "$raw" | sed '/^[[:space:]]*$/d')"
+  [[ -n "$findings" ]] || return 0
+
+  printf '**#%s** — [the review](%s)\n%s\n' "$issue" "$url" "$findings"
+}
+
 # The FIXABLE count out of a verdict line ("" when there is no line).
 verdict_fixable() {
   [[ -n "$1" ]] || { echo ""; return; }
@@ -516,10 +560,29 @@ pr_title() {
 
 pr_body() {
   local -a issues=("$@")
-  local body="Autonomous run — issues in this PR:" n
+  local body="Autonomous run — issues in this PR:" n block advisory=""
   for n in "${issues[@]}"; do
     body+=$'\n'"- #${n} $(issue_title "$n")"
   done
+
+  # Every advisory finding the run raised, gathered here from the issues that
+  # raised them. Reading them together is the part a single issue's comment
+  # cannot give you: one smell across three issues of the same batch is not
+  # three notes, it is a pattern, and probably a line in AGENTS.md.
+  for n in "${issues[@]}"; do
+    block="$(issue_advisory "$n")"
+    [[ -n "$block" ]] && advisory+=$'\n\n'"$block"
+  done
+  if [[ -n "$advisory" ]]; then
+    body+=$'\n\n'"## Advisory — raised, and deliberately not acted on"
+    body+=$'\n\n'"The review sessions found these and left them alone on purpose: smells, scope"
+    body+=$'\n'"creep, weak tests, judgement calls. **This is the moment to decide on them** —"
+    body+=$'\n'"you have the diff in front of you. Whatever you don't act on here goes back to"
+    body+=$'\n'"being findable only in a comment on a closed issue, so decide rather than defer:"
+    body+=$'\n'"open a ticket for what should outlive this PR, and let the rest go on purpose."
+    body+="$advisory"
+  fi
+
   body+=$'\n\n'"Draft — review, then merge into \`$RALPH_BASE_REF\`."
   echo "$body"
 }

--- a/seed/store-expectation.ts
+++ b/seed/store-expectation.ts
@@ -41,6 +41,7 @@ export interface DocumentInput {
 export interface Expectation {
   content: Set<string>;
   contentTags: Set<string>;
+  project: Set<string>;
   series: Set<string>;
   sections: Set<string>;
 }
@@ -70,6 +71,7 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
   const expectation: Expectation = {
     content: new Set<string>(),
     contentTags: new Set<string>(),
+    project: new Set<string>(),
     series: new Set<string>(),
     sections: new Set<string>(),
   };
@@ -110,6 +112,15 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
     } else if (placed.type === "link") {
       expectation.content.add(`${slug}:`);
       addTags(expectation.contentTags, slug, "", attributes.tags);
+    } else if (placed.type === "project") {
+      // A Project is not a Content Item — no Published At, no place in the
+      // Timeline — so it is its own set, keyed the same way `project-sql.ts`
+      // keys the row it seeds.
+      if (lang === null || !localeMatchesTree(placed.tree, lang)) {
+        continue;
+      }
+
+      expectation.project.add(`${slug}:${lang}`);
     } else if (placed.type === "series") {
       if (lang === null || !localeMatchesTree(placed.tree, lang)) {
         continue;

--- a/seed/store-expectation.ts
+++ b/seed/store-expectation.ts
@@ -1,0 +1,149 @@
+/**
+ * What the Markdown says the stores should hold, derived from placement.
+ *
+ * `verify-stores.ts` keeps the disk, `wrangler` and the console; this module
+ * owns the decision — which Document belongs in which table, under which
+ * identity — so that decision can be tested without either. ADR 0012 draws the
+ * line this module keeps to: it shares the classification rules with the
+ * generators (`placementOf`, `parseContentFilename`, `localeMatchesTree`),
+ * which say what a Document *is*, and it never imports a row builder or reads
+ * `seed.sql`, which say what a Document *becomes* — those are exactly what a
+ * verifier exists to doubt.
+ *
+ * Until this module existed, the rule was `attributes.type` — the front
+ * matter dispatch ADR 0004 removed from the generators three phases ago,
+ * alive in the one place whose job was catching it. `attributes.type` is not
+ * read here, at all: a Document's identity is read off its path, the same way
+ * the generators decide it.
+ */
+
+import { basenameOf, isMisplaced, localeMatchesTree, placementOf } from "./d1/content-tree.ts";
+import { parseContentFilename } from "./d1/seed-sql.ts";
+
+/** A Markdown file, read but not yet decided: its path and its front matter. */
+export interface DocumentInput {
+  /** Relative to `app/content` — the same identity `placementOf` reads. */
+  relativePath: string;
+  /**
+   * Untyped at this boundary, like every reader upstream of a build check: this
+   * is YAML, so a stricter type here would be a claim about a file nobody has
+   * checked. `type` is deliberately absent from this shape — this module never
+   * reads it.
+   */
+  attributes: {
+    tags?: unknown;
+    sections?: Array<{ slug: string }>;
+    draft?: unknown;
+  };
+}
+
+/** What the Markdown says each table should hold, keyed by identity. */
+export interface Expectation {
+  content: Set<string>;
+  contentTags: Set<string>;
+  series: Set<string>;
+  sections: Set<string>;
+}
+
+/** One table's presence comparison: what the Markdown expects against what a store holds. */
+export interface PresenceFinding {
+  noun: string;
+  expectedCount: number;
+  /** Expected identities absent from the store — what a prune exists to prevent. */
+  missing: string[];
+  /** Identities present in the store that no Markdown file backs. */
+  extra: string[];
+}
+
+/** One `content_tag` row per Tag the file carries, keyed as the prune keys it. */
+function addTags(tags: Set<string>, slug: string, lang: string, values: unknown) {
+  for (const tag of Array.isArray(values) ? values : []) {
+    tags.add(`${slug}:${lang}:${tag}`);
+  }
+}
+
+/**
+ * Derives what every table should hold from a set of Documents, classified by
+ * placement rather than by what their front matter declares.
+ */
+export function expectationFrom(documents: DocumentInput[]): Expectation {
+  const expectation: Expectation = {
+    content: new Set<string>(),
+    contentTags: new Set<string>(),
+    series: new Set<string>(),
+    sections: new Set<string>(),
+  };
+
+  for (const { relativePath, attributes } of documents) {
+    // `draft: true` produces no row, of any type — mirrored leniently: this
+    // module's job is comparing what publishes against what is stored, not
+    // re-validating that the flag is a boolean, which the build already
+    // refuses to seed from if it is not.
+    if (attributes.draft === true) {
+      continue;
+    }
+
+    const placed = placementOf(relativePath);
+
+    if (isMisplaced(placed)) {
+      continue;
+    }
+
+    const parsed = parseContentFilename(basenameOf(relativePath));
+
+    if (!parsed) {
+      continue;
+    }
+
+    const { slug, lang } = parsed;
+
+    if (placed.type === "post") {
+      // `lang === null` leads the condition so TypeScript narrows `lang` to
+      // `string` below — the same reason `series-sql.ts` and `project-sql.ts`
+      // write the check this way.
+      if (lang === null || !localeMatchesTree(placed.tree, lang)) {
+        continue;
+      }
+
+      expectation.content.add(`${slug}:${lang}`);
+      addTags(expectation.contentTags, slug, lang, attributes.tags);
+    } else if (placed.type === "link") {
+      expectation.content.add(`${slug}:`);
+      addTags(expectation.contentTags, slug, "", attributes.tags);
+    } else if (placed.type === "series") {
+      if (lang === null || !localeMatchesTree(placed.tree, lang)) {
+        continue;
+      }
+
+      expectation.series.add(`${slug}:${lang}`);
+
+      // The sections are read straight off the manifest, not off the
+      // generated SQL: a generator that dropped one would otherwise agree
+      // with itself (ADR 0012).
+      for (const section of attributes.sections ?? []) {
+        expectation.sections.add(`${slug}:${lang}:${section.slug}`);
+      }
+    }
+  }
+
+  return expectation;
+}
+
+/**
+ * Both directions, per table: a row the Markdown does not back is as wrong as
+ * one it backs and the store is missing. The second is the one a prune exists
+ * to prevent — a Section dropped from a manifest keeps rendering on the
+ * landing until something notices it is still there.
+ */
+export function comparePresence(
+  noun: string,
+  expected: Set<string>,
+  present: Set<string>,
+): PresenceFinding {
+  return {
+    noun,
+    expectedCount: expected.size,
+    missing: [...expected].filter((key) => !present.has(key)),
+    extra: [...present].filter((key) => !expected.has(key)),
+  };
+}

--- a/seed/verify-stores.ts
+++ b/seed/verify-stores.ts
@@ -5,6 +5,7 @@ import fm from "front-matter";
 
 import { KV_PREFIXES, kvKeyFor } from "./kv/kv-keys.ts";
 import { listPayloadFiles } from "./kv/payload-files.ts";
+import { comparePresence, expectationFrom, type DocumentInput } from "./store-expectation.ts";
 
 /**
  * Asserts that a seeded store actually holds what this repo says it should.
@@ -44,14 +45,6 @@ interface SeriesSectionRow {
     slug: string;
 }
 
-/** What the Markdown says each table should hold, keyed by identity. */
-interface Expectation {
-    content: Set<string>;
-    contentTags: Set<string>;
-    series: Set<string>;
-    sections: Set<string>;
-}
-
 function wrangler(args: string[], wranglerArgs: string[]): string {
     return execFileSync("pnpm", ["exec", "wrangler", ...args, ...wranglerArgs], {
         encoding: "utf-8",
@@ -74,37 +67,17 @@ function d1Query<T>(sql: string, wranglerArgs: string[]): T[] {
 }
 
 /**
- * The Markdown files are the source of truth, so the expectation is derived from
- * them rather than from the generated SQL — otherwise a generator that silently
- * dropped a file would produce a seed and a verification that agree with each
- * other and with nothing else.
- *
- * The rule mirrors `generate-seed-sql.ts` exactly, including what it skips: a
- * document declaring `draft: true`, whatever its type, is not seeded, so it is
- * not expected here either. A Post whose filename carries no recognised
- * Locale fails the build there rather than being skipped, so this script
- * should never see one on a checkout that built at all — but it is excluded
- * from the expectation here too, leniently, since re-validating that is not
- * this script's job.
+ * Every Markdown file under `app/content`, read but not yet classified: the
+ * path relative to `CONTENT_DIR` and the raw front matter. Classifying what
+ * each one is, and what it means for the stores, is `store-expectation.ts`'s
+ * job — this script owns only the disk (ADR 0012).
  */
-async function expectedFromMarkdown(): Promise<Expectation> {
-    const expectation: Expectation = {
-        content: new Set<string>(),
-        contentTags: new Set<string>(),
-        series: new Set<string>(),
-        sections: new Set<string>(),
-    };
+async function readContentDir(dir: string): Promise<DocumentInput[]> {
+    const documents: DocumentInput[] = [];
 
-    /** Keyed as the prune keys it: the Content Item's identity plus the Tag. */
-    const addTags = (slug: string, locale: string, tags: unknown) => {
-        for (const tag of Array.isArray(tags) ? tags : []) {
-            expectation.contentTags.add(`${slug}:${locale}:${tag}`);
-        }
-    };
-
-    async function walk(dir: string) {
-        for (const entry of await fsPromise.readdir(dir, { withFileTypes: true })) {
-            const full = path.join(dir, entry.name);
+    async function walk(current: string) {
+        for (const entry of await fsPromise.readdir(current, { withFileTypes: true })) {
+            const full = path.join(current, entry.name);
 
             if (entry.isDirectory()) {
                 await walk(full);
@@ -115,56 +88,17 @@ async function expectedFromMarkdown(): Promise<Expectation> {
                 continue;
             }
 
-            const match = entry.name.match(/^(.*?)(?:\.(en|es))?\.md$/);
+            const { attributes } = fm<DocumentInput["attributes"]>(
+                await fsPromise.readFile(full, "utf-8"),
+            );
 
-            if (!match) {
-                continue;
-            }
-
-            const [, slug, locale] = match;
-            const { attributes } = fm<{
-                type?: string;
-                tags?: unknown;
-                sections?: Array<{ slug: string }>;
-                draft?: unknown;
-            }>(await fsPromise.readFile(full, "utf-8"));
-
-            // `draft: true` produces no row, of any type — mirrored leniently:
-            // this script's job is comparing what publishes against what is
-            // stored, not re-validating that the flag is a boolean, which the
-            // build already refuses to seed from if it is not.
-            if (attributes.draft === true) {
-                continue;
-            }
-
-            if (attributes.type === "post") {
-                // A Post with no recognised Locale in its filename fails the
-                // build in `contentRowFor` rather than seeding a row — mirrored
-                // here as an exclusion rather than a throw, since this script
-                // is not the place that check belongs.
-                if (locale) {
-                    expectation.content.add(`${slug}:${locale}`);
-                    addTags(slug, locale, attributes.tags);
-                }
-            } else if (attributes.type === "link") {
-                expectation.content.add(`${slug}:`);
-                addTags(slug, "", attributes.tags);
-            } else if (attributes.type === "series" && locale) {
-                expectation.series.add(`${slug}:${locale}`);
-
-                // The sections are read straight off the manifest, not off the
-                // generated SQL, for the reason above: a generator that dropped
-                // one would otherwise agree with itself.
-                for (const section of attributes.sections ?? []) {
-                    expectation.sections.add(`${slug}:${locale}:${section.slug}`);
-                }
-            }
+            documents.push({ relativePath: path.relative(dir, full), attributes });
         }
     }
 
-    await walk(CONTENT_DIR);
+    await walk(dir);
 
-    return expectation;
+    return documents;
 }
 
 function report(label: string, ok: boolean, detail: string): boolean {
@@ -179,7 +113,15 @@ async function verify(mode: string): Promise<boolean> {
 
     console.log(`==> D1 (${mode})`);
 
-    const expected = await expectedFromMarkdown();
+    // The Markdown files are the source of truth, so the expectation is
+    // derived from them rather than from the generated SQL — otherwise a
+    // generator that silently dropped a file would produce a seed and a
+    // verification that agree with each other and with nothing else
+    // (ADR 0012). Classifying what each file is happens by placement, not by
+    // its front matter's `type` — `store-expectation.ts` is where that rule
+    // is shared with the generators, tested, and singular.
+    const documents = await readContentDir(CONTENT_DIR);
+    const expected = expectationFrom(documents);
 
     const contentRows = d1Query<ContentRow>("select slug, lang, type from content", wranglerArgs);
     const tagRows = d1Query<ContentTagRow>("select slug, lang, tag from content_tag", wranglerArgs);
@@ -189,30 +131,25 @@ async function verify(mode: string): Promise<boolean> {
         wranglerArgs,
     );
 
-    /**
-     * Both directions, per table: a row the Markdown does not back is as wrong
-     * as one it backs and the store is missing. The second is the one a prune
-     * exists to prevent — a section dropped from a manifest keeps rendering on
-     * the landing until something notices it is still there.
-     */
-    const compareKeys = (noun: string, expectedKeys: Set<string>, presentKeys: Set<string>) => {
-        const missing = [...expectedKeys].filter((key) => !presentKeys.has(key));
-        const extra = [...presentKeys].filter((key) => !expectedKeys.has(key));
+    const presenceFindings = [
+        comparePresence("Content Item", expected.content,
+            new Set(contentRows.map((row) => `${row.slug}:${row.lang ?? ""}`))),
+        comparePresence("Tag row", expected.contentTags,
+            new Set(tagRows.map((row) => `${row.slug}:${row.lang ?? ""}:${row.tag}`))),
+        comparePresence("Series", expected.series,
+            new Set(seriesRows.map((row) => `${row.slug}:${row.lang}`))),
+        comparePresence("Series Section", expected.sections,
+            new Set(sectionRows.map((row) => `${row.series_slug}:${row.lang}:${row.slug}`))),
+    ];
 
-        passed = report(`every ${noun} present`, missing.length === 0,
-            missing.length === 0 ? `${expectedKeys.size} rows` : `missing: ${missing.join(", ")}`) && passed;
-        passed = report(`no ${noun} left behind`, extra.length === 0,
-            extra.length === 0 ? "none" : `unexpected: ${extra.join(", ")}`) && passed;
-    };
-
-    compareKeys("Content Item", expected.content,
-        new Set(contentRows.map((row) => `${row.slug}:${row.lang ?? ""}`)));
-    compareKeys("Tag row", expected.contentTags,
-        new Set(tagRows.map((row) => `${row.slug}:${row.lang ?? ""}:${row.tag}`)));
-    compareKeys("Series", expected.series,
-        new Set(seriesRows.map((row) => `${row.slug}:${row.lang}`)));
-    compareKeys("Series Section", expected.sections,
-        new Set(sectionRows.map((row) => `${row.series_slug}:${row.lang}:${row.slug}`)));
+    // The comparison itself is `store-expectation.ts`'s: this only formats the
+    // findings it returns through the reporting this script already has.
+    for (const finding of presenceFindings) {
+        passed = report(`every ${finding.noun} present`, finding.missing.length === 0,
+            finding.missing.length === 0 ? `${finding.expectedCount} rows` : `missing: ${finding.missing.join(", ")}`) && passed;
+        passed = report(`no ${finding.noun} left behind`, finding.extra.length === 0,
+            finding.extra.length === 0 ? "none" : `unexpected: ${finding.extra.join(", ")}`) && passed;
+    }
 
     console.log(`==> KV (${mode})`);
 

--- a/seed/verify-stores.ts
+++ b/seed/verify-stores.ts
@@ -34,6 +34,11 @@ interface ContentTagRow {
     tag: string;
 }
 
+interface ProjectRow {
+    slug: string;
+    lang: string;
+}
+
 interface SeriesRow {
     slug: string;
     lang: string;
@@ -125,6 +130,7 @@ async function verify(mode: string): Promise<boolean> {
 
     const contentRows = d1Query<ContentRow>("select slug, lang, type from content", wranglerArgs);
     const tagRows = d1Query<ContentTagRow>("select slug, lang, tag from content_tag", wranglerArgs);
+    const projectRows = d1Query<ProjectRow>("select slug, lang from project", wranglerArgs);
     const seriesRows = d1Query<SeriesRow>("select slug, lang from series", wranglerArgs);
     const sectionRows = d1Query<SeriesSectionRow>(
         "select series_slug, lang, slug from series_section",
@@ -136,6 +142,8 @@ async function verify(mode: string): Promise<boolean> {
             new Set(contentRows.map((row) => `${row.slug}:${row.lang ?? ""}`))),
         comparePresence("Tag row", expected.contentTags,
             new Set(tagRows.map((row) => `${row.slug}:${row.lang ?? ""}:${row.tag}`))),
+        comparePresence("Project", expected.project,
+            new Set(projectRows.map((row) => `${row.slug}:${row.lang}`))),
         comparePresence("Series", expected.series,
             new Set(seriesRows.map((row) => `${row.slug}:${row.lang}`))),
         comparePresence("Series Section", expected.sections,

--- a/tests/unit/seed/store-expectation.test.ts
+++ b/tests/unit/seed/store-expectation.test.ts
@@ -120,18 +120,75 @@ describe("expectationFrom — placement and Locale", () => {
   });
 
   /**
-   * The exact gap ADR 0012 opens with: `type: 'project'` had no branch at all
-   * in the old dispatch, so the `project` table was never compared. This
-   * ticket does not close that gap — it is #55 — but a Project landing must
-   * not accidentally classify as a Content Item or a Series either.
+   * A Project landing must not accidentally classify as a Content Item or a
+   * Series — it is neither: no Published At, no place in the Timeline.
    */
-  it("expects nothing at all for a Project landing — the project table has no expectation here yet", () => {
+  it("expects a Project landing in the project set, not as a Content Item or a Series", () => {
     const docs = [document("projects/chekalo/chekalo.en.md")];
 
     const expectation = expectationFrom(docs);
 
     expect(expectation.content.size).toBe(0);
     expect(expectation.series.size).toBe(0);
+  });
+});
+
+describe("expectationFrom — a Project", () => {
+  /**
+   * The exact gap #52 opens with: `type: 'project'` had no branch at all in
+   * the old dispatch, so the `project` table was never compared. This is the
+   * branch that closes it.
+   */
+  it("expects a Project at (Slug, Locale), keyed the same way project-sql.ts keys the row", () => {
+    const docs = [document("projects/chekalo/chekalo.en.md")];
+
+    expect(expectationFrom(docs).project).toEqual(new Set(["chekalo:en"]));
+  });
+
+  it("expects nothing for a Project manifest declaring itself a Draft", () => {
+    const docs = [document("projects/chekalo/chekalo.en.md", { draft: true })];
+
+    expect(expectationFrom(docs).project.size).toBe(0);
+  });
+});
+
+describe("comparePresence — the project table, both directions", () => {
+  /**
+   * The observable outcome #52 built the acceptance around: a wrong prune of
+   * `project` used to pass a Publication in silence, because the old dispatch
+   * had no branch for it at all. `comparePresence` is what names the row that
+   * went missing — the same function every other table already uses, now fed
+   * from the `project` set.
+   */
+  it("names a Project the Markdown backs that a prune dropped from the table", () => {
+    const docs = [
+      document("projects/chekalo/chekalo.en.md"),
+      document("projects/poschuler-com/poschuler-com.en.md"),
+    ];
+
+    const expected = expectationFrom(docs).project;
+    const present = new Set(["chekalo:en"]);
+
+    expect(comparePresence("Project", expected, present)).toEqual({
+      noun: "Project",
+      expectedCount: 2,
+      missing: ["poschuler-com:en"],
+      extra: [],
+    });
+  });
+
+  it("names a row in the table that no Project manifest backs", () => {
+    const docs = [document("projects/chekalo/chekalo.en.md")];
+
+    const expected = expectationFrom(docs).project;
+    const present = new Set(["chekalo:en", "retired-project:en"]);
+
+    expect(comparePresence("Project", expected, present)).toEqual({
+      noun: "Project",
+      expectedCount: 1,
+      missing: [],
+      extra: ["retired-project:en"],
+    });
   });
 });
 

--- a/tests/unit/seed/store-expectation.test.ts
+++ b/tests/unit/seed/store-expectation.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  comparePresence,
+  expectationFrom,
+  type DocumentInput,
+} from "../../../seed/store-expectation";
+
+/**
+ * ADR 0012: the verifier stops deciding what a Document is by reading its
+ * front matter, and starts classifying by placement — the same rule the
+ * generators use (ADR 0004). This is the module the decision now lives in,
+ * pure and shared, so it can be tested without a database and without
+ * `wrangler`.
+ *
+ * The failure this replaces was silent: `verify-stores.ts` used to dispatch on
+ * `attributes.type`, which had no branch for `project`, so a wrong prune of a
+ * Project passed the Publication without a word. Placement has no such gap —
+ * `attributes.type` is not read here, at all.
+ */
+
+const document = (
+  relativePath: string,
+  attributes: Record<string, unknown> = {},
+): DocumentInput => ({ relativePath, attributes: attributes as DocumentInput["attributes"] });
+
+describe("expectationFrom — classifies by placement, not by declared type", () => {
+  it("expects a Post at (Slug, Locale) whatever its front matter declares itself to be", () => {
+    const docs = [document("blog/value-objects/value-objects.en.md", { type: "note" })];
+
+    expect(expectationFrom(docs).content).toEqual(new Set(["value-objects:en"]));
+  });
+
+  it("expects a Bookmark keyed with no Locale", () => {
+    const docs = [document("bookmarks/how-i-would-do-auth.md")];
+
+    expect(expectationFrom(docs).content).toEqual(new Set(["how-i-would-do-auth:"]));
+  });
+});
+
+describe("expectationFrom — Tags", () => {
+  it("keys a Tag row to the Content Item plus the Tag", () => {
+    const docs = [
+      document("blog/value-objects/value-objects.en.md", { tags: ["nodejs", "typescript"] }),
+    ];
+
+    expect(expectationFrom(docs).contentTags).toEqual(
+      new Set(["value-objects:en:nodejs", "value-objects:en:typescript"]),
+    );
+  });
+});
+
+describe("expectationFrom — a Series and its Sections", () => {
+  it("expects the Series and every Section its manifest lists, keyed by position in the file", () => {
+    const docs = [
+      document("series/pragmatic-nodejs-api/pragmatic-nodejs-api.en.md", {
+        sections: [{ slug: "fundamentals" }, { slug: "persistence" }],
+      }),
+    ];
+
+    const expectation = expectationFrom(docs);
+
+    expect(expectation.series).toEqual(new Set(["pragmatic-nodejs-api:en"]));
+    expect(expectation.sections).toEqual(
+      new Set(["pragmatic-nodejs-api:en:fundamentals", "pragmatic-nodejs-api:en:persistence"]),
+    );
+  });
+});
+
+describe("expectationFrom — Drafts", () => {
+  it("expects nothing for a Document declaring draft: true", () => {
+    const docs = [document("blog/value-objects/value-objects.en.md", { draft: true })];
+
+    expect(expectationFrom(docs).content.size).toBe(0);
+  });
+
+  /**
+   * A malformed `draft` is the build's mistake to catch, not this module's —
+   * ADR 0012 draws the line here: leniency survives for content states, only
+   * a placement that will not classify is fatal, and it is a later ticket
+   * that makes that fatal, not this one.
+   */
+  it("expects a Document whose draft value is not a boolean, rather than re-validating it", () => {
+    const docs = [document("blog/value-objects/value-objects.en.md", { draft: "true" })];
+
+    expect(expectationFrom(docs).content).toEqual(new Set(["value-objects:en"]));
+  });
+});
+
+describe("expectationFrom — a Field Note, nested the same way a Part is", () => {
+  it("expects a Field Note the same way it expects a loose Post", () => {
+    const docs = [document("projects/chekalo/product-matching/product-matching.en.md")];
+
+    expect(expectationFrom(docs).content).toEqual(new Set(["product-matching:en"]));
+  });
+});
+
+describe("expectationFrom — placement and Locale", () => {
+  it("expects nothing for a path that will not classify", () => {
+    const docs = [document("drafts/something.en.md")];
+
+    expect(expectationFrom(docs).content.size).toBe(0);
+  });
+
+  it("expects nothing for a Post with no recognised Locale under a tree that requires one", () => {
+    const docs = [document("blog/no-locale/no-locale.md")];
+
+    expect(expectationFrom(docs).content.size).toBe(0);
+  });
+
+  it("expects nothing for a Series manifest with no recognised Locale", () => {
+    const docs = [
+      document("series/api/api.md", { sections: [{ slug: "fundamentals" }] }),
+    ];
+
+    const expectation = expectationFrom(docs);
+
+    expect(expectation.series.size).toBe(0);
+    expect(expectation.sections.size).toBe(0);
+  });
+
+  /**
+   * The exact gap ADR 0012 opens with: `type: 'project'` had no branch at all
+   * in the old dispatch, so the `project` table was never compared. This
+   * ticket does not close that gap — it is #55 — but a Project landing must
+   * not accidentally classify as a Content Item or a Series either.
+   */
+  it("expects nothing at all for a Project landing — the project table has no expectation here yet", () => {
+    const docs = [document("projects/chekalo/chekalo.en.md")];
+
+    const expectation = expectationFrom(docs);
+
+    expect(expectation.content.size).toBe(0);
+    expect(expectation.series.size).toBe(0);
+  });
+});
+
+describe("comparePresence", () => {
+  it("names what the Markdown expects that the store is missing", () => {
+    const finding = comparePresence("Content Item", new Set(["a:en", "b:en"]), new Set(["a:en"]));
+
+    expect(finding).toEqual({ noun: "Content Item", expectedCount: 2, missing: ["b:en"], extra: [] });
+  });
+
+  it("names what the store holds that no Markdown file backs — the row a prune exists to remove", () => {
+    const finding = comparePresence("Content Item", new Set(["a:en"]), new Set(["a:en", "orphan:en"]));
+
+    expect(finding).toEqual({ noun: "Content Item", expectedCount: 1, missing: [], extra: ["orphan:en"] });
+  });
+
+  it("finds nothing wrong when expected and present agree", () => {
+    const finding = comparePresence("Content Item", new Set(["a:en"]), new Set(["a:en"]));
+
+    expect(finding.missing).toEqual([]);
+    expect(finding.extra).toEqual([]);
+  });
+});


### PR DESCRIPTION
Autonomous run — issues in this PR:
- #54 The verifier classifies by placement, in a tested pure module
- #55 The Project table enters the expectation

## Advisory — raised, and deliberately not acted on

The review sessions found these and left them alone on purpose: smells, scope
creep, weak tests, judgement calls. **This is the moment to decide on them** —
you have the diff in front of you. Whatever you don't act on here goes back to
being findable only in a comment on a closed issue, so decide rather than defer:
open a ticket for what should outlive this PR, and let the rest go on purpose.

**#54** — [the review](https://github.com/poschuler/poschuler.com/issues/54#issuecomment-5319394585)
- ADR 0012's "an empty expectation is a failure for `content`" floor check is still unimplemented in `store-expectation.ts`/`verify-stores.ts` — pre-existing, not introduced by this diff.
- Minor Duplicated Code: the `lang === null || !localeMatchesTree(...)` check and its comment repeat verbatim in the `post` and `series` branches of `expectationFrom`.
- Three tests ("expects nothing for a path that will not classify," the Post-Locale and Series-Locale equivalents) confirmed a guard that was written ahead of them rather than driving it — self-disclosed by the implementer, not hidden, but worth knowing the TDD discipline slipped there.
- Criterion 1's closing-comment "Verified" grep claim says "returns nothing" when it actually returns two docblock-prose matches; the underlying claim (no code reads `attributes.type`) is genuinely true.

**#55** — [the review](https://github.com/poschuler/poschuler.com/issues/55#issuecomment-5319581152)
- Standards (JUDGEMENT): the locale guard `lang === null || !localeMatchesTree(placed.tree, lang)` is now duplicated a fourth time across the `post`/`link`/`series`/`project` branches in `seed/store-expectation.ts`; a reasonable reviewer could leave it, since it matches the file's existing convention.
- Tests (WEAK): the renamed test `"expects a Project landing in the project set, not as a Content Item or a Series"` (`tests/unit/seed/store-expectation.test.ts:126`) has a title claiming project-set coverage its unchanged body doesn't assert — it only checks `expectation.content.size` and `expectation.series.size`, never `expectation.project`.
- Spec/evidence (unsupported claim, not a code defect): the closing comment's criterion-6 evidence — `"18 in store-expectation.test.ts, up from 16"` — is inaccurate; the file held 14 top-level tests before this commit (confirmed via `git show cbc50f4457bb17c1ce1192efd0d370c47c6cc7844:tests/unit/seed/store-expectation.test.ts`), not 16, so it went 14→18.

Draft — review, then merge into `dev`.