### PR TITLE
ralph: #56, #57, #58 — The Container columns on every Content Item are verified (+2 more)

### DIFF
--- a/ralph/RALPH.md
+++ b/ralph/RALPH.md
@@ -424,6 +424,13 @@ Command-line flags: `--dry-run`, `--max-iterations N`, `-h`/`--help`.
 - **A `- [ ]` anywhere in the body is a criterion.** The guard doesn't work out
   which list a box belongs to, because a rule that has to would be read two ways
   by two readers. A checkbox in an issue is something to be earned.
+- **Evidence in the closing comment is quoted, not remembered.** The numbers and
+  outputs the implementer reports are checked against the diff by the Tests axis,
+  and the first run of two issues turned up an inaccuracy in each: a test count
+  compared against a figure nobody had measured, and a `grep` described as
+  returning nothing when it returned two matches in prose. Both arguments were
+  sound and both pieces of evidence were not, which is worse than offering none —
+  it makes a reader wonder what else was reconstructed at the end.
 - **TDD is asked for explicitly, and it is paid for in the closing comment.**
   The implementer works one criterion at a time — failing test, watch it fail
   for the right reason, smallest code that passes, tidy while green — and its
@@ -446,6 +453,17 @@ Command-line flags: `--dry-run`, `--max-iterations N`, `-h`/`--help`.
   commit is the one that matters: it would land inside the range the fix session
   inherits as "the implementation", so the third session would end up applying a
   review to work the reviewer wrote after reviewing.
+- **`FIXABLE` means objective, and two things can disqualify a finding from it.**
+  If two axes looked at the same change and reached opposite conclusions, it is
+  advisory however either of them labelled it — two careful readers disagreeing
+  is the definition of not objective. And a finding whose own text says "confirm
+  the scope with Paul" has already been judged not objective by the session that
+  wrote it. Both rules exist because #54 produced exactly that item: Standards
+  read a docblock as a broken rule, Spec read the same change as deliberately
+  deferred, and it went out as the sole thing to fix. The fixer refused it,
+  correctly and with three citations, having spent a whole session on it.
+  Catching the disagreement is the aggregator's job, and only it can — the three
+  axes are blind to each other by design.
 - **The Tests axis reads the closing comment, not just the diff.** It is the one
   that can tell you the implementer's account of its own work doesn't hold — a
   test named that isn't there, a failure message that test could not have

--- a/ralph/prompts/1-implement.md
+++ b/ralph/prompts/1-implement.md
@@ -123,6 +123,27 @@ And where the ticket named no seam and you had to choose one, add a **Seam**
 line saying which you chose and why. A seam nobody agreed to is worth flagging
 while the reason is still fresh.
 
+### Evidence is quoted, never remembered
+
+Every number and every piece of output in that comment comes from something you
+watched a command print, in this session. Not from memory, not from an estimate,
+not from what the number usually is. This is the part of the report that gets
+checked against the diff, and both times it has gone wrong it went wrong the
+same way — by describing rather than copying:
+
+- **A comparison nobody measured.** *"18 tests, up from 16"* — the 18 was real
+  and the 16 was invented, because knowing it would have meant counting on the
+  commit before this one. It was 14. Either run `git show <sha>:<file>` and
+  count, or give the number you have and make no comparison at all.
+- **An output described instead of pasted.** *"`grep …` returns nothing"*, when
+  it returned two matches in docblock prose. The point being argued was true;
+  the evidence offered for it was not, which is worse than offering none.
+
+Nobody is asking for an impressive number. They are asking for **the** number. A
+line of evidence that turns out to be approximate costs more than a line never
+written: it invites a reader to wonder what else in the account was reconstructed
+at the end rather than seen along the way.
+
 ## Two rules
 
 Both outrank anything else you might have been trained to do at the end of a

--- a/ralph/prompts/2-review.md
+++ b/ralph/prompts/2-review.md
@@ -117,6 +117,12 @@ verbatim or lightly cleaned. **Do not merge them or rank one against the
 other** — a change can pass one axis and fail another, and keeping them apart is
 what stops one from masking the rest.
 
+**Before you classify, read the three reports against each other.** You are the
+only session that can: each axis judged the diff blind to the other two, so the
+one thing none of them could notice is that two of them looked at the same change
+and reached opposite conclusions about it. Presenting them apart still stands —
+what you are hunting for is not a merge, it is a contradiction.
+
 Then classify every finding into exactly one of two buckets, because the third
 session acts on this and on nothing else:
 
@@ -131,16 +137,34 @@ session acts on this and on nothing else:
   the code at all. All of them are for Paul to scope, not for an unattended
   session to act on.
 
-**If Tests returned anything `UNSUPPORTED`, say so in the first line of your
-report**, before the sections. It is the one finding that isn't about this diff:
-it says the account the implementer gave of its own work doesn't hold, and that
-bears on how much of the rest of that account to believe.
+Two rules override those labels, and both exist because `FIXABLE` means
+*objective* — it is the list a session acts on with nobody to ask:
+
+- **Two axes, opposite conclusions about the same change → ADVISORY**, whatever
+  they each called it. Two careful readers arriving at opposite readings is the
+  definition of not objective. Name which axes disagreed and on what; that
+  disagreement is usually more informative than either report alone.
+- **A finding whose own text asks for a human decision cannot be `FIXABLE`.** If
+  you find yourself writing "confirm the scope with Paul" into an item, you have
+  already judged it not objective — classify it that way instead of sending it to
+  a session that has nobody to confirm anything with. On 17 Aug 2026 exactly this
+  reached the fix session as the sole thing to fix (#54): Standards read a
+  docblock as a broken rule, Spec read the same change as deliberately deferred
+  to a later ticket, and the item went out carrying both the `HARD` label and the
+  suggestion to check with Paul. The fixer refused it, correctly and with three
+  citations — after a whole session spent concluding there was nothing to do.
+
+**Lead with the first line of your report** when either of these happened, before
+the sections: an axis disagreement, or an `UNSUPPORTED` from Tests. Neither is a
+finding about the diff. One says two readings of this change exist and you should
+pick; the other says the account the implementer gave of its own work doesn't
+hold, which bears on how much of the rest to believe.
 
 Post the whole thing as a comment on the issue — `gh issue comment {{N}}
 --body-file <file>` — laid out as:
 
 ```
-…one line, only if Tests returned an UNSUPPORTED finding…
+…one line, only if two axes disagreed or Tests returned an UNSUPPORTED finding…
 
 ## Standards
 …the sub-agent's report…

--- a/seed/store-expectation.ts
+++ b/seed/store-expectation.ts
@@ -17,7 +17,13 @@
  * the generators decide it.
  */
 
-import { basenameOf, isMisplaced, localeMatchesTree, placementOf } from "./d1/content-tree.ts";
+import {
+  basenameOf,
+  isMisplaced,
+  localeMatchesTree,
+  pathSegments,
+  placementOf,
+} from "./d1/content-tree.ts";
 import { parseContentFilename } from "./d1/seed-sql.ts";
 
 /** A Markdown file, read but not yet decided: its path and its front matter. */
@@ -32,9 +38,24 @@ export interface DocumentInput {
    */
   attributes: {
     tags?: unknown;
-    sections?: Array<{ slug: string }>;
+    sections?: Array<{ slug: string; parts?: string[] }>;
+    /** A Project manifest's Field Notes, in the order its landing renders them. */
+    notes?: unknown;
     draft?: unknown;
   };
+}
+
+/**
+ * A Content Item's Container, as its placement and the manifest that lists it
+ * say it should be — never both `seriesSlug` and `projectSlug` at once, the
+ * same way `content.series_slug` and `content.project_slug` never both hold a
+ * value (`schema.sql`).
+ */
+export interface ContainerColumns {
+  seriesSlug: string | null;
+  seriesSection: string | null;
+  projectSlug: string | null;
+  containerOrder: number | null;
 }
 
 /** What the Markdown says each table should hold, keyed by identity. */
@@ -44,7 +65,17 @@ export interface Expectation {
   project: Set<string>;
   series: Set<string>;
   sections: Set<string>;
+  /** A Content Item's identity → its expected Container columns. */
+  containers: Map<string, ContainerColumns>;
 }
+
+/** A Content Item with no Container — a loose Post, a Bookmark. */
+const NO_CONTAINER: ContainerColumns = {
+  seriesSlug: null,
+  seriesSection: null,
+  projectSlug: null,
+  containerOrder: null,
+};
 
 /** One table's presence comparison: what the Markdown expects against what a store holds. */
 export interface PresenceFinding {
@@ -56,11 +87,78 @@ export interface PresenceFinding {
   extra: string[];
 }
 
+/**
+ * One Container column that disagrees between what the Markdown expects and
+ * what a store holds — named by the Content Item's identity and the column,
+ * never as a missing/unexpected pair. A wrong `container_order` is one number
+ * against another, not one long identifier missing and a different one
+ * showing up unannounced.
+ */
+export interface ContainerFinding {
+  identity: string;
+  column: keyof ContainerColumns;
+  stored: string | number | null;
+  expected: string | number | null;
+}
+
 /** One `content_tag` row per Tag the file carries, keyed as the prune keys it. */
 function addTags(tags: Set<string>, slug: string, lang: string, values: unknown) {
   for (const tag of Array.isArray(values) ? values : []) {
     tags.add(`${slug}:${lang}:${tag}`);
   }
+}
+
+/** Where a Part sits, as its Series manifest lists it: its Section and its position in that list. */
+interface PartLocation {
+  section: string;
+  order: number;
+}
+
+/**
+ * Every Part's and every Field Note's position, read raw off the manifests in
+ * `documents` — an indexed iteration over the same array `series-sql.ts` and
+ * `project-sql.ts` read, and nothing else (ADR 0012). Keyed by Container
+ * folder, Locale and the Part's or Note's own Slug, because a manifest only
+ * governs the Locale it is itself written in.
+ */
+function readManifestPlacements(documents: DocumentInput[]): {
+  parts: Map<string, PartLocation>;
+  notes: Map<string, number>;
+} {
+  const parts = new Map<string, PartLocation>();
+  const notes = new Map<string, number>();
+
+  for (const { relativePath, attributes } of documents) {
+    const placed = placementOf(relativePath);
+
+    if (isMisplaced(placed) || placed.container !== null) {
+      continue;
+    }
+
+    const parsed = parseContentFilename(basenameOf(relativePath));
+
+    if (!parsed || parsed.lang === null || !localeMatchesTree(placed.tree, parsed.lang)) {
+      continue;
+    }
+
+    const folder = pathSegments(relativePath)[1];
+
+    if (placed.type === "series") {
+      for (const section of attributes.sections ?? []) {
+        (section.parts ?? []).forEach((partSlug, order) => {
+          parts.set(`${folder}:${parsed.lang}:${partSlug}`, { section: section.slug, order });
+        });
+      }
+    } else if (placed.type === "project") {
+      const noteSlugs = Array.isArray(attributes.notes) ? (attributes.notes as string[]) : [];
+
+      noteSlugs.forEach((noteSlug, order) => {
+        notes.set(`${folder}:${parsed.lang}:${noteSlug}`, order);
+      });
+    }
+  }
+
+  return { parts, notes };
 }
 
 /**
@@ -74,7 +172,10 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
     project: new Set<string>(),
     series: new Set<string>(),
     sections: new Set<string>(),
+    containers: new Map<string, ContainerColumns>(),
   };
+
+  const manifestPlacements = readManifestPlacements(documents);
 
   for (const { relativePath, attributes } of documents) {
     // `draft: true` produces no row, of any type — mirrored leniently: this
@@ -109,9 +210,31 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
 
       expectation.content.add(`${slug}:${lang}`);
       addTags(expectation.contentTags, slug, lang, attributes.tags);
+
+      if (placed.container === null) {
+        expectation.containers.set(`${slug}:${lang}`, NO_CONTAINER);
+      } else if (placed.tree === "series") {
+        const location = manifestPlacements.parts.get(`${placed.container}:${lang}:${slug}`);
+
+        expectation.containers.set(`${slug}:${lang}`, {
+          ...NO_CONTAINER,
+          seriesSlug: placed.container,
+          seriesSection: location?.section ?? null,
+          containerOrder: location?.order ?? null,
+        });
+      } else if (placed.tree === "projects") {
+        const order = manifestPlacements.notes.get(`${placed.container}:${lang}:${slug}`);
+
+        expectation.containers.set(`${slug}:${lang}`, {
+          ...NO_CONTAINER,
+          projectSlug: placed.container,
+          containerOrder: order ?? null,
+        });
+      }
     } else if (placed.type === "link") {
       expectation.content.add(`${slug}:`);
       addTags(expectation.contentTags, slug, "", attributes.tags);
+      expectation.containers.set(`${slug}:`, NO_CONTAINER);
     } else if (placed.type === "project") {
       // A Project is not a Content Item — no Published At, no place in the
       // Timeline — so it is its own set, keyed the same way `project-sql.ts`
@@ -157,4 +280,49 @@ export function comparePresence(
     missing: [...expected].filter((key) => !present.has(key)),
     extra: [...present].filter((key) => !expected.has(key)),
   };
+}
+
+const CONTAINER_COLUMNS: (keyof ContainerColumns)[] = [
+  "seriesSlug",
+  "seriesSection",
+  "projectSlug",
+  "containerOrder",
+];
+
+/**
+ * Column by column, for every identity the Markdown expects a Container
+ * shape for: a Part's Series and Section, a Field Note's Project, either
+ * one's position, or a loose Post's absence of all four (ADR 0012's "value on
+ * a row that already exists").
+ *
+ * An identity missing from `present` is skipped, not reported here — the
+ * presence comparison already names it missing, and reporting it again as
+ * four disagreeing columns would say the same thing twice, in two shapes.
+ */
+export function compareContainers(
+  expected: Map<string, ContainerColumns>,
+  present: Map<string, ContainerColumns>,
+): ContainerFinding[] {
+  const findings: ContainerFinding[] = [];
+
+  for (const [identity, expectedColumns] of expected) {
+    const storedColumns = present.get(identity);
+
+    if (!storedColumns) {
+      continue;
+    }
+
+    for (const column of CONTAINER_COLUMNS) {
+      if (storedColumns[column] !== expectedColumns[column]) {
+        findings.push({
+          identity,
+          column,
+          stored: storedColumns[column],
+          expected: expectedColumns[column],
+        });
+      }
+    }
+  }
+
+  return findings;
 }

--- a/seed/store-expectation.ts
+++ b/seed/store-expectation.ts
@@ -67,6 +67,8 @@ export interface Expectation {
   sections: Set<string>;
   /** A Content Item's identity → its expected Container columns. */
   containers: Map<string, ContainerColumns>;
+  /** A Series Section's identity → its expected position in the manifest's arc. */
+  sectionOrder: Map<string, number>;
 }
 
 /** A Content Item with no Container — a loose Post, a Bookmark. */
@@ -173,6 +175,7 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
     series: new Set<string>(),
     sections: new Set<string>(),
     containers: new Map<string, ContainerColumns>(),
+    sectionOrder: new Map<string, number>(),
   };
 
   const manifestPlacements = readManifestPlacements(documents);
@@ -251,12 +254,17 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
 
       expectation.series.add(`${slug}:${lang}`);
 
-      // The sections are read straight off the manifest, not off the
-      // generated SQL: a generator that dropped one would otherwise agree
-      // with itself (ADR 0012).
-      for (const section of attributes.sections ?? []) {
-        expectation.sections.add(`${slug}:${lang}:${section.slug}`);
-      }
+      // The sections, and each one's position in the arc, are read straight
+      // off the manifest's own array — an indexed iteration and nothing else
+      // — not off the generated SQL: a generator that dropped one, or wrote
+      // it at the wrong position, would otherwise agree with itself
+      // (ADR 0012).
+      (attributes.sections ?? []).forEach((section, index) => {
+        const identity = `${slug}:${lang}:${section.slug}`;
+
+        expectation.sections.add(identity);
+        expectation.sectionOrder.set(identity, index);
+      });
     }
   }
 
@@ -280,6 +288,43 @@ export function comparePresence(
     missing: [...expected].filter((key) => !present.has(key)),
     extra: [...present].filter((key) => !expected.has(key)),
   };
+}
+
+/**
+ * One Series Section whose stored position disagrees with the index its
+ * manifest lists it at — named by the Section's identity and both positions,
+ * the same reasoning as `ContainerFinding`: a wrong position is one number
+ * against another, not a missing row plus an unexpected one.
+ */
+export interface SectionOrderFinding {
+  identity: string;
+  stored: number;
+  expected: number;
+}
+
+/**
+ * The Container comparison's reasoning applied one level up: a Series
+ * Section's own position in the arc is a value on a row that already
+ * exists, not a presence set. An identity missing from `present` is skipped
+ * here too — the presence comparison for Sections already names it missing.
+ */
+export function compareSectionOrder(
+  expected: Map<string, number>,
+  present: Map<string, number>,
+): SectionOrderFinding[] {
+  const findings: SectionOrderFinding[] = [];
+
+  for (const [identity, expectedOrder] of expected) {
+    const storedOrder = present.get(identity);
+
+    if (storedOrder === undefined || storedOrder === expectedOrder) {
+      continue;
+    }
+
+    findings.push({ identity, stored: storedOrder, expected: expectedOrder });
+  }
+
+  return findings;
 }
 
 const CONTAINER_COLUMNS: (keyof ContainerColumns)[] = [

--- a/seed/store-expectation.ts
+++ b/seed/store-expectation.ts
@@ -15,6 +15,14 @@
  * alive in the one place whose job was catching it. `attributes.type` is not
  * read here, at all: a Document's identity is read off its path, the same way
  * the generators decide it.
+ *
+ * A placement `placementOf` cannot classify, and a filename carrying no
+ * recognised Locale under a tree that requires one, throw rather than being
+ * skipped: both are things a Document *is*, and a Document that yields no
+ * expectation is indistinguishable from one that is correct once all that is
+ * left is a set comparison. A Draft, and a `draft` that is not a boolean, are
+ * still skipped quietly — those are things a Document *says*, and the build
+ * already owns them (#58, ADR 0012).
  */
 
 import {
@@ -23,6 +31,7 @@ import {
   localeMatchesTree,
   pathSegments,
   placementOf,
+  type ContentTree,
 } from "./d1/content-tree.ts";
 import { parseContentFilename } from "./d1/seed-sql.ts";
 
@@ -110,6 +119,16 @@ function addTags(tags: Set<string>, slug: string, lang: string, values: unknown)
   }
 }
 
+/**
+ * The message a Post, a Project landing or a Series manifest fails the
+ * verification with when its filename carries no recognised Locale under a
+ * tree that requires one — one wording, shared by every branch that checks
+ * it, rather than three copies free to drift apart (#58).
+ */
+function noRecognisedLocale(relativePath: string, tree: ContentTree): string {
+  return `${relativePath} carries no recognised Locale — a file under ${tree}/ must end in .en.md or .es.md`;
+}
+
 /** Where a Part sits, as its Series manifest lists it: its Section and its position in that list. */
 interface PartLocation {
   section: string;
@@ -191,8 +210,16 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
 
     const placed = placementOf(relativePath);
 
+    // A placement `placementOf` cannot classify is a thing a Document *is*,
+    // read off its path — not something the build already owns, the way a
+    // Draft is. Skipping it would make it indistinguishable from a Document
+    // that is correct: comparing sets finds nothing wrong either way. This is
+    // the one invocation with nothing earlier catching it (`remote` measures
+    // the deployed store, and nothing guarantees the checkout that runs this
+    // is the one that seeded it), so it stops the run rather than being
+    // absorbed (#58, ADR 0012).
     if (isMisplaced(placed)) {
-      continue;
+      throw new Error(placed.error);
     }
 
     const parsed = parseContentFilename(basenameOf(relativePath));
@@ -206,9 +233,12 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
     if (placed.type === "post") {
       // `lang === null` leads the condition so TypeScript narrows `lang` to
       // `string` below — the same reason `series-sql.ts` and `project-sql.ts`
-      // write the check this way.
+      // write the check this way. A filename carrying no recognised Locale
+      // under a tree that requires one is the same fatal shape as a
+      // placement that will not classify — it is what the file *is*, not
+      // what it *says* — so it stops the run too (#58).
       if (lang === null || !localeMatchesTree(placed.tree, lang)) {
-        continue;
+        throw new Error(noRecognisedLocale(relativePath, placed.tree));
       }
 
       expectation.content.add(`${slug}:${lang}`);
@@ -241,15 +271,15 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
     } else if (placed.type === "project") {
       // A Project is not a Content Item — no Published At, no place in the
       // Timeline — so it is its own set, keyed the same way `project-sql.ts`
-      // keys the row it seeds.
+      // keys the row it seeds. No recognised Locale is fatal here too (#58).
       if (lang === null || !localeMatchesTree(placed.tree, lang)) {
-        continue;
+        throw new Error(noRecognisedLocale(relativePath, placed.tree));
       }
 
       expectation.project.add(`${slug}:${lang}`);
     } else if (placed.type === "series") {
       if (lang === null || !localeMatchesTree(placed.tree, lang)) {
-        continue;
+        throw new Error(noRecognisedLocale(relativePath, placed.tree));
       }
 
       expectation.series.add(`${slug}:${lang}`);
@@ -269,6 +299,20 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
   }
 
   return expectation;
+}
+
+/**
+ * Whether the Content Item expectation derived to nothing — the one state
+ * `generate-seed-sql.ts` already treats as impossible (`buildSeedSql`'s own
+ * guard against an empty walk emptying the live table): comparing two empty
+ * sets finds nothing wrong in either direction, so a broken derivation — a
+ * path constant that moves, a directory read that fails quietly — would
+ * otherwise certify an empty store as correct. Scoped to Content Items alone:
+ * a Project, a Series and a Series Section may legitimately be absent, since
+ * the schema ships before the first one is written (#58).
+ */
+export function isEmptyContentExpectation(expectation: Expectation): boolean {
+  return expectation.content.size === 0;
 }
 
 /**

--- a/seed/verify-stores.ts
+++ b/seed/verify-stores.ts
@@ -10,6 +10,7 @@ import {
   comparePresence,
   compareSectionOrder,
   expectationFrom,
+  isEmptyContentExpectation,
   type ContainerColumns,
   type DocumentInput,
 } from "./store-expectation.ts";
@@ -152,6 +153,17 @@ async function verify(mode: string): Promise<boolean> {
     // is shared with the generators, tested, and singular.
     const documents = await readContentDir(CONTENT_DIR);
     const expected = expectationFrom(documents);
+
+    // A broken derivation — a path constant that moves, a directory read
+    // that fails quietly — would otherwise produce an empty expectation, and
+    // an empty expectation compared against an empty store finds nothing
+    // wrong in either direction: the presence check below would pass and
+    // certify an empty `content` table. `generate-seed-sql.ts` already treats
+    // this state as impossible; the verifier now agrees (#58).
+    passed = report("Content Item expectation is not empty", !isEmptyContentExpectation(expected),
+        isEmptyContentExpectation(expected)
+            ? "derived to nothing — a broken derivation would certify an empty store"
+            : `${expected.content.size} expected`) && passed;
 
     const contentRows = d1Query<ContentRow>("select slug, lang, type from content", wranglerArgs);
     const tagRows = d1Query<ContentTagRow>("select slug, lang, tag from content_tag", wranglerArgs);

--- a/seed/verify-stores.ts
+++ b/seed/verify-stores.ts
@@ -8,6 +8,7 @@ import { listPayloadFiles } from "./kv/payload-files.ts";
 import {
   compareContainers,
   comparePresence,
+  compareSectionOrder,
   expectationFrom,
   type ContainerColumns,
   type DocumentInput,
@@ -64,6 +65,14 @@ interface SeriesSectionRow {
     series_slug: string;
     lang: string;
     slug: string;
+}
+
+/** A Series Section's own position in the arc, read back alongside its identity. */
+interface SeriesSectionOrderRow {
+    series_slug: string;
+    lang: string;
+    slug: string;
+    section_order: number;
 }
 
 function wrangler(args: string[], wranglerArgs: string[]): string {
@@ -156,6 +165,10 @@ async function verify(mode: string): Promise<boolean> {
         "select slug, lang, series_slug, series_section, project_slug, container_order from content",
         wranglerArgs,
     );
+    const sectionOrderRows = d1Query<SeriesSectionOrderRow>(
+        "select series_slug, lang, slug, section_order from series_section",
+        wranglerArgs,
+    );
 
     const presenceFindings = [
         comparePresence("Content Item", expected.content,
@@ -201,6 +214,24 @@ async function verify(mode: string): Promise<boolean> {
             ? `${expected.containers.size} rows`
             : containerFindings
                 .map((finding) => `${finding.identity} ${finding.column}: stored ${finding.stored ?? "null"}, expected ${finding.expected ?? "null"}`)
+                .join("; ")) && passed;
+
+    // Symmetric to the Container comparison, one level up: a Section's own
+    // position in the arc is a value on a row that already exists, not a
+    // presence difference (#57).
+    const presentSectionOrder = new Map<string, number>(
+        sectionOrderRows.map((row) => [
+            `${row.series_slug}:${row.lang}:${row.slug}`,
+            row.section_order,
+        ]),
+    );
+    const sectionOrderFindings = compareSectionOrder(expected.sectionOrder, presentSectionOrder);
+
+    passed = report("every Series Section position agrees", sectionOrderFindings.length === 0,
+        sectionOrderFindings.length === 0
+            ? `${expected.sectionOrder.size} rows`
+            : sectionOrderFindings
+                .map((finding) => `${finding.identity}: stored ${finding.stored}, expected ${finding.expected}`)
                 .join("; ")) && passed;
 
     console.log(`==> KV (${mode})`);

--- a/seed/verify-stores.ts
+++ b/seed/verify-stores.ts
@@ -5,7 +5,13 @@ import fm from "front-matter";
 
 import { KV_PREFIXES, kvKeyFor } from "./kv/kv-keys.ts";
 import { listPayloadFiles } from "./kv/payload-files.ts";
-import { comparePresence, expectationFrom, type DocumentInput } from "./store-expectation.ts";
+import {
+  compareContainers,
+  comparePresence,
+  expectationFrom,
+  type ContainerColumns,
+  type DocumentInput,
+} from "./store-expectation.ts";
 
 /**
  * Asserts that a seeded store actually holds what this repo says it should.
@@ -32,6 +38,16 @@ interface ContentTagRow {
     slug: string;
     lang: string | null;
     tag: string;
+}
+
+/** The Container columns on `content`, read back with the identity that keys them. */
+interface ContentContainerRow {
+    slug: string;
+    lang: string | null;
+    series_slug: string | null;
+    series_section: string | null;
+    project_slug: string | null;
+    container_order: number | null;
 }
 
 interface ProjectRow {
@@ -136,6 +152,10 @@ async function verify(mode: string): Promise<boolean> {
         "select series_slug, lang, slug from series_section",
         wranglerArgs,
     );
+    const containerRows = d1Query<ContentContainerRow>(
+        "select slug, lang, series_slug, series_section, project_slug, container_order from content",
+        wranglerArgs,
+    );
 
     const presenceFindings = [
         comparePresence("Content Item", expected.content,
@@ -158,6 +178,30 @@ async function verify(mode: string): Promise<boolean> {
         passed = report(`no ${finding.noun} left behind`, finding.extra.length === 0,
             finding.extra.length === 0 ? "none" : `unexpected: ${finding.extra.join(", ")}`) && passed;
     }
+
+    // A Container is a value on a row that already exists, not a presence
+    // difference — comparing it keyed on identity is what names a wrong
+    // `container_order` as itself, rather than as one missing row plus one
+    // unexpected row (ADR 0012).
+    const presentContainers = new Map<string, ContainerColumns>(
+        containerRows.map((row) => [
+            `${row.slug}:${row.lang ?? ""}`,
+            {
+                seriesSlug: row.series_slug,
+                seriesSection: row.series_section,
+                projectSlug: row.project_slug,
+                containerOrder: row.container_order,
+            },
+        ]),
+    );
+    const containerFindings = compareContainers(expected.containers, presentContainers);
+
+    passed = report("every Container column agrees", containerFindings.length === 0,
+        containerFindings.length === 0
+            ? `${expected.containers.size} rows`
+            : containerFindings
+                .map((finding) => `${finding.identity} ${finding.column}: stored ${finding.stored ?? "null"}, expected ${finding.expected ?? "null"}`)
+                .join("; ")) && passed;
 
     console.log(`==> KV (${mode})`);
 

--- a/tests/unit/seed/store-expectation.test.ts
+++ b/tests/unit/seed/store-expectation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  compareContainers,
   comparePresence,
   expectationFrom,
   type DocumentInput,
@@ -189,6 +190,147 @@ describe("comparePresence — the project table, both directions", () => {
       missing: [],
       extra: ["retired-project:en"],
     });
+  });
+});
+
+/**
+ * #56: the Container columns on `content` — `series_slug`, `series_section`,
+ * `project_slug` and `container_order` — join the expectation. Presence is a
+ * set difference; a Container is a value on a row that already exists, so it
+ * gets its own comparison keyed by identity rather than widening `content`
+ * (ADR 0012, and the ticket's own reasoning for why widening was rejected).
+ */
+describe("expectationFrom — the Container columns", () => {
+  it("expects a loose Post to have no Container", () => {
+    const docs = [document("blog/value-objects/value-objects.en.md")];
+
+    expect(expectationFrom(docs).containers.get("value-objects:en")).toEqual({
+      seriesSlug: null,
+      seriesSection: null,
+      projectSlug: null,
+      containerOrder: null,
+    });
+  });
+
+  it("expects a Part's Series to be the Series it sits under, as its placement says", () => {
+    const docs = [
+      document(
+        "series/pragmatic-nodejs-api/project-setup/project-setup.en.md",
+      ),
+    ];
+
+    expect(expectationFrom(docs).containers.get("project-setup:en")?.seriesSlug).toBe(
+      "pragmatic-nodejs-api",
+    );
+  });
+
+  it("expects a Field Note's Project to be the Project it sits under, as its placement says", () => {
+    const docs = [document("projects/chekalo/product-matching/product-matching.en.md")];
+
+    expect(expectationFrom(docs).containers.get("product-matching:en")?.projectSlug).toBe(
+      "chekalo",
+    );
+  });
+
+  it("expects a Part's Series Section to be the Section that lists it in the manifest", () => {
+    const docs = [
+      document("series/pragmatic-nodejs-api/pragmatic-nodejs-api.en.md", {
+        sections: [
+          { slug: "fundamentals", parts: ["project-setup"] },
+          { slug: "persistence", parts: ["repositories"] },
+        ],
+      }),
+      document("series/pragmatic-nodejs-api/repositories/repositories.en.md"),
+    ];
+
+    expect(expectationFrom(docs).containers.get("repositories:en")?.seriesSection).toBe(
+      "persistence",
+    );
+  });
+
+  it("expects a Part's position to be the index its Section's manifest lists it at", () => {
+    const docs = [
+      document("series/pragmatic-nodejs-api/pragmatic-nodejs-api.en.md", {
+        sections: [
+          { slug: "fundamentals", parts: ["project-setup", "schema-validation", "vertical-slices"] },
+        ],
+      }),
+      document("series/pragmatic-nodejs-api/vertical-slices/vertical-slices.en.md"),
+    ];
+
+    expect(expectationFrom(docs).containers.get("vertical-slices:en")?.containerOrder).toBe(2);
+  });
+
+  it("expects a Field Note's position to be the index its Project's manifest lists it at", () => {
+    const docs = [
+      document("projects/chekalo/chekalo.en.md", {
+        notes: ["product-matching", "onboarding-flow"],
+      }),
+      document("projects/chekalo/onboarding-flow/onboarding-flow.en.md"),
+    ];
+
+    expect(expectationFrom(docs).containers.get("onboarding-flow:en")?.containerOrder).toBe(1);
+  });
+});
+
+/**
+ * The comparison ADR 0012 says a Container needs and presence does not give:
+ * a value on a row that already exists, named by column rather than reported
+ * as one missing item plus one unexpected item — two long identifiers to diff
+ * by eye (the ticket's own reasoning for rejecting a widened `content` key).
+ */
+describe("compareContainers", () => {
+  it("names a Container column that disagrees, with the identity, the column, the stored value and the expected value", () => {
+    const expected = new Map([
+      [
+        "repositories:en",
+        { seriesSlug: "pragmatic-nodejs-api", seriesSection: "persistence", projectSlug: null, containerOrder: 1 },
+      ],
+    ]);
+    const present = new Map([
+      [
+        "repositories:en",
+        { seriesSlug: "pragmatic-nodejs-api", seriesSection: "fundamentals", projectSlug: null, containerOrder: 1 },
+      ],
+    ]);
+
+    expect(compareContainers(expected, present)).toEqual([
+      { identity: "repositories:en", column: "seriesSection", stored: "fundamentals", expected: "persistence" },
+    ]);
+  });
+
+  it("fails a row that claims a Container for a Content Item the Markdown expects loose", () => {
+    const expected = new Map([
+      ["value-objects:en", { seriesSlug: null, seriesSection: null, projectSlug: null, containerOrder: null }],
+    ]);
+    const present = new Map([
+      [
+        "value-objects:en",
+        { seriesSlug: "pragmatic-nodejs-api", seriesSection: "fundamentals", projectSlug: null, containerOrder: 0 },
+      ],
+    ]);
+
+    expect(compareContainers(expected, present)).toEqual([
+      { identity: "value-objects:en", column: "seriesSlug", stored: "pragmatic-nodejs-api", expected: null },
+      { identity: "value-objects:en", column: "seriesSection", stored: "fundamentals", expected: null },
+      { identity: "value-objects:en", column: "containerOrder", stored: 0, expected: null },
+    ]);
+  });
+
+  it("finds nothing wrong when every column agrees", () => {
+    const columns = { seriesSlug: "pragmatic-nodejs-api", seriesSection: "fundamentals", projectSlug: null, containerOrder: 0 };
+    const expected = new Map([["project-setup:en", columns]]);
+    const present = new Map([["project-setup:en", { ...columns }]]);
+
+    expect(compareContainers(expected, present)).toEqual([]);
+  });
+
+  it("skips an identity the store has no row for — the presence comparison already names it missing", () => {
+    const expected = new Map([
+      ["repositories:en", { seriesSlug: "pragmatic-nodejs-api", seriesSection: "persistence", projectSlug: null, containerOrder: 1 }],
+    ]);
+
+    expect(compareContainers(expected, new Map())).toEqual([]);
   });
 });
 

--- a/tests/unit/seed/store-expectation.test.ts
+++ b/tests/unit/seed/store-expectation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   compareContainers,
   comparePresence,
+  compareSectionOrder,
   expectationFrom,
   type DocumentInput,
 } from "../../../seed/store-expectation";
@@ -65,6 +66,20 @@ describe("expectationFrom — a Series and its Sections", () => {
     expect(expectation.sections).toEqual(
       new Set(["pragmatic-nodejs-api:en:fundamentals", "pragmatic-nodejs-api:en:persistence"]),
     );
+  });
+});
+
+describe("expectationFrom — a Series Section's position in the arc", () => {
+  it("expects a Section's position to be the index its manifest lists it at", () => {
+    const docs = [
+      document("series/pragmatic-nodejs-api/pragmatic-nodejs-api.en.md", {
+        sections: [{ slug: "fundamentals" }, { slug: "persistence" }],
+      }),
+    ];
+
+    expect(
+      expectationFrom(docs).sectionOrder.get("pragmatic-nodejs-api:en:persistence"),
+    ).toBe(1);
   });
 });
 
@@ -331,6 +346,37 @@ describe("compareContainers", () => {
     ]);
 
     expect(compareContainers(expected, new Map())).toEqual([]);
+  });
+});
+
+/**
+ * #57: symmetric to #56 at one level up — a Series Section's own position in
+ * the arc, derived from its index in the manifest's `sections` array, gets
+ * the same kind of comparison a Part's `container_order` already has: a value
+ * on a row that already exists, named by the Section's identity and both
+ * positions rather than as a missing/unexpected pair.
+ */
+describe("compareSectionOrder", () => {
+  it("names a Section whose stored position disagrees with the manifest's, with its identity and both positions", () => {
+    const expected = new Map([["pragmatic-nodejs-api:en:persistence", 1]]);
+    const present = new Map([["pragmatic-nodejs-api:en:persistence", 0]]);
+
+    expect(compareSectionOrder(expected, present)).toEqual([
+      { identity: "pragmatic-nodejs-api:en:persistence", stored: 0, expected: 1 },
+    ]);
+  });
+
+  it("finds nothing wrong when the stored position agrees with the manifest's", () => {
+    const expected = new Map([["pragmatic-nodejs-api:en:persistence", 1]]);
+    const present = new Map([["pragmatic-nodejs-api:en:persistence", 1]]);
+
+    expect(compareSectionOrder(expected, present)).toEqual([]);
+  });
+
+  it("skips a Section the store has no row for — the presence comparison already names it missing", () => {
+    const expected = new Map([["pragmatic-nodejs-api:en:persistence", 1]]);
+
+    expect(compareSectionOrder(expected, new Map())).toEqual([]);
   });
 });
 

--- a/tests/unit/seed/store-expectation.test.ts
+++ b/tests/unit/seed/store-expectation.test.ts
@@ -5,6 +5,7 @@ import {
   comparePresence,
   compareSectionOrder,
   expectationFrom,
+  isEmptyContentExpectation,
   type DocumentInput,
 } from "../../../seed/store-expectation";
 
@@ -112,27 +113,40 @@ describe("expectationFrom — a Field Note, nested the same way a Part is", () =
 });
 
 describe("expectationFrom — placement and Locale", () => {
-  it("expects nothing for a path that will not classify", () => {
+  /**
+   * #58: a Document that yields no expectation used to be indistinguishable
+   * from one that is correct — comparing sets makes nothing-against-nothing
+   * pass forever. A placement `placementOf` cannot classify is a thing a
+   * Document *is*, read off its path, so it now stops the run rather than
+   * being skipped — naming the file and the reason, the same shape
+   * `generate-seed-sql.ts` already fails the build with.
+   */
+  it("fails on a Document whose placement will not classify, naming the file and the reason", () => {
     const docs = [document("drafts/something.en.md")];
 
-    expect(expectationFrom(docs).content.size).toBe(0);
+    expect(() => expectationFrom(docs)).toThrow(
+      "drafts/something.en.md is not under a content tree — nothing would read it and nothing would say so",
+    );
   });
 
-  it("expects nothing for a Post with no recognised Locale under a tree that requires one", () => {
+  it("fails on a Post with no recognised Locale under a tree that requires one, naming the file", () => {
     const docs = [document("blog/no-locale/no-locale.md")];
 
-    expect(expectationFrom(docs).content.size).toBe(0);
+    expect(() => expectationFrom(docs)).toThrow(/blog\/no-locale\/no-locale\.md/);
   });
 
-  it("expects nothing for a Series manifest with no recognised Locale", () => {
+  it("fails on a Series manifest with no recognised Locale, naming the file", () => {
     const docs = [
       document("series/api/api.md", { sections: [{ slug: "fundamentals" }] }),
     ];
 
-    const expectation = expectationFrom(docs);
+    expect(() => expectationFrom(docs)).toThrow(/series\/api\/api\.md/);
+  });
 
-    expect(expectation.series.size).toBe(0);
-    expect(expectation.sections.size).toBe(0);
+  it("fails on a Project landing with no recognised Locale, naming the file", () => {
+    const docs = [document("projects/chekalo/chekalo.md")];
+
+    expect(() => expectationFrom(docs)).toThrow(/projects\/chekalo\/chekalo\.md/);
   });
 
   /**
@@ -399,4 +413,44 @@ describe("comparePresence", () => {
     expect(finding.missing).toEqual([]);
     expect(finding.extra).toEqual([]);
   });
+});
+
+/**
+ * #58: comparing two sets makes nothing-against-nothing pass forever, so a
+ * broken derivation — a path constant that moves, a directory read that fails
+ * quietly — would certify an empty store as correct. `generate-seed-sql.ts`
+ * already treats an empty walk as impossible (`buildSeedSql`'s own guard);
+ * the verifier now agrees, for Content Items alone.
+ */
+describe("isEmptyContentExpectation", () => {
+  it("is true when nothing expects a Content Item", () => {
+    expect(isEmptyContentExpectation(expectationFrom([]))).toBe(true);
+  });
+
+  it("is false once at least one Content Item is expected", () => {
+    const docs = [document("blog/value-objects/value-objects.en.md")];
+
+    expect(isEmptyContentExpectation(expectationFrom(docs))).toBe(false);
+  });
+});
+
+/**
+ * The floor #58 refuses to generalise: a Project, a Series and a Series
+ * Section may legitimately be absent — the schema ships before the first one
+ * is written, and that was the normal state until two phases ago. Claiming a
+ * floor there would be a false alarm waiting for someone to delete content on
+ * purpose.
+ */
+describe("comparePresence — an empty expectation for Project, Series or Series Section stays legal", () => {
+  it.each(["Project", "Series", "Series Section"])(
+    "finds nothing wrong when both %s sides are empty",
+    (noun) => {
+      expect(comparePresence(noun, new Set(), new Set())).toEqual({
+        noun,
+        expectedCount: 0,
+        missing: [],
+        extra: [],
+      });
+    },
+  );
 });


### PR DESCRIPTION
Autonomous run — issues in this PR:
- #56 The Container columns on every Content Item are verified
- #57 The Series Section's position in the arc is verified
- #58 Silence stops being success: what will not classify fails the verification

## Advisory — raised, and deliberately not acted on

The review sessions found these and left them alone on purpose: smells, scope
creep, weak tests, judgement calls. **This is the moment to decide on them** —
you have the diff in front of you. Whatever you don't act on here goes back to
being findable only in a comment on a closed issue, so decide rather than defer:
open a ticket for what should outlive this PR, and let the rest go on purpose.

**#56** — [the review](https://github.com/poschuler/poschuler.com/issues/56#issuecomment-5320004781)
- Whether the Bookmark/link `NO_CONTAINER` path (`store-expectation.ts:237`) needs its own direct test in `describe("expectationFrom — the Container columns")`: Spec calls this a gap in criterion 8 (`MISSING`), Tests calls the suite's coverage `SUPPORTED overall` with no unjustified `UNTESTED` gap. Two careful reads of the same coverage question disagree, which is the definition of not objective — Paul's call whether the identical-constant, different-branch case is worth its own assertion.

**#57** — [the review](https://github.com/poschuler/poschuler.com/issues/57#issuecomment-5320131196)
- Standards (`JUDGEMENT`): `compareSectionOrder` in `seed/store-expectation.ts` repeats the shape of `compareContainers` just above it (iterate expected, skip absent, push a stored/expected finding on mismatch) — possible mild Duplicated Code, though ADR 0012's stated preference for independent, naive comparators plausibly excuses it as intentional.

**#58** — [the review](https://github.com/poschuler/poschuler.com/issues/58#issuecomment-5320354344)
- Standards (JUDGEMENT): `noRecognisedLocale` breaks from the repo's own `<thing>Error` naming convention (`draftError`, `tagError` in `seed/d1/seed-sql.ts`) — a Mysterious-Name smell, not a documented-rule break.
- Standards (JUDGEMENT): the Locale-check-and-throw condition (`lang === null || !localeMatchesTree(...)`) is repeated across the Post/Project/Series branches in `seed/store-expectation.ts` — Duplicated Code; could collapse into one guard, though the pre-existing shape (three `continue`s) already had this duplication before the diff.
- Standards (JUDGEMENT): `seed/verify-stores.ts` calls `isEmptyContentExpectation(expected)` twice to get the ok-flag and the detail string — minor redundant recomputation, though it matches this file's pre-existing `report(...)` pattern.
- Tests (WEAK): the AC6 test (`comparePresence — an empty expectation for Project, Series or Series Section stays legal`) never ran red-first, and the closing comment's "No test" / "Test —" phrasing is confusingly worded — though the assertion itself is a legitimate, independent check against the public `comparePresence` export, not tautological.
- Spec (note, not formally MISSING/WRONG): the issue's own prose frames the empty-Content-Item check as making the verification "stop the run," the same language used for the two `throw`-based cases, but the implementation only marks the run failed via `report(...)` and continues executing the remaining D1/KV checks — the checked acceptance-criterion text ("fails the verification") is still satisfied, so this is advisory framing feedback, not a defect.

Draft — review, then merge into `dev`.