### PR TITLE
ralph: #61 The duplication the verifier sequence left behind, and two tests that promise more than they check

### DIFF
--- a/ralph/RALPH.md
+++ b/ralph/RALPH.md
@@ -80,16 +80,28 @@ observable behaviour per line** (something a test or a command can answer), and
 cannot settle is what sends the issue back to you labelled `needs-info`, which
 is the right outcome but a slow one.
 
-**Optional PRD auto-close.** If an issue belongs to a PRD and you want Ralph to
-close that PRD when the last child is done, add a line to the issue body:
+**Say which map a ticket belongs to, and ralph closes the map for you.** When
+every child of a map is closed, the runner comments and closes it — once per
+map, after the whole list drains. It looks in two places, in this order:
 
-```
-PRD: #19
-```
+1. **GitHub's native sub-issue link**, which is what `docs/agents/issue-tracker.md`
+   calls a child ticket:
+   `gh api --method POST repos/<owner>/<repo>/issues/<map>/sub_issues -F sub_issue_id=<child-db-id>`,
+   where the id is the child's numeric **database** id (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`),
+   not its `#number`. Prefer this: GitHub answers it in both directions and shows
+   the map's progress in its own UI.
+2. **A `## Parent` section** naming the map, which is what the issues in this
+   repo write today:
 
-After closing an issue, the session lists the siblings that declare the same
-`PRD: #NN`; if they're all closed, it closes the PRD too. No `PRD:` line → that
-step is simply skipped.
+   ```markdown
+   ## Parent
+
+   #52
+   ```
+
+Either works, neither is required — a ticket with no map is closed and nothing
+else happens. A map with **any** child still open stays open, and the run says
+which children it is waiting on.
 
 ### 2. List the issues to work
 
@@ -399,6 +411,7 @@ the review's report and the fixer's account of what it applied and refused.
 | `RALPH_DISALLOWED_TOOLS`| `ScheduleWakeup`    | Space-separated tools banned in **every** session (`""` = none). |
 | `RALPH_BLOCK_CODE_REVIEW` | `1`               | Enforce "no code review in this session" with a `PreToolUse` hook instead of trusting the prompt. Needs `jq`. `0` = prompts only. |
 | `RALPH_VERIFY`          | `1`                 | Run the pre-commit checklist after every commit a session makes, instead of believing it ran green. `0` = take their word. |
+| `RALPH_CLOSE_PARENT`    | `1`                 | Close a map once every child has landed. Finds it via the native sub-issue link, then via `## Parent`. |
 | `RALPH_CHECKLIST`       | the five in `AGENTS.md` | What that checklist is — one command line per entry, in order, each retried once before it counts as red. |
 | `RALPH_PROMPT_FILE`     | `ralph/prompts/1-implement.md` | What the implementation session is told. A relative path is read from the repo root. |
 | `RALPH_REVIEW_PROMPT_FILE` | `ralph/prompts/2-review.md` | What the review session is told.                     |
@@ -504,5 +517,16 @@ Command-line flags: `--dry-run`, `--max-iterations N`, `-h`/`--help`.
   `summary.md` row to see which issue broke. The worktree is left intact;
   fix it, then re-run — closed issues stay skipped and ralph resumes from the
   next open one.
-- **PRD auto-close needs the `PRD: #NN` line** in the issue body. Without it,
-  ralph closes the issue but never touches a PRD.
+- **A map closes when its last child lands, and the runner is the one who asks.**
+  It finds the map through GitHub's **native sub-issue link** first — what
+  `docs/agents/issue-tracker.md` calls a child ticket — and falls back to reading
+  the `## Parent` section the issues here actually write. Then, once per map and
+  only after the whole list drains: every child closed → comment and close;
+  anything still open → say which, and leave it.
+  This was the implementation session's errand until 17 Aug 2026 and never once
+  fired, because the prompt looked for a `PRD: #NN` line that no issue in this
+  repo has ever carried — while this file documented that line as the mechanism
+  and `issue-tracker.md` documented sub-issues as the convention. Three
+  conventions, none of them running. It is also the wrong job for a session:
+  "are all the siblings closed" has an answer rather than a judgement, and a
+  session only ever sees one ticket. `RALPH_CLOSE_PARENT=0` turns it off.

--- a/ralph/prompts/1-implement.md
+++ b/ralph/prompts/1-implement.md
@@ -71,8 +71,10 @@ Skip nothing, and keep the order:
 
 6. **Commit to the current branch**, one commit, in this repo's commit format.
 
-7. **Close the issue with the report below.** If the issue names a PRD and this
-   was its last open child, close the PRD too, with a summary comment.
+7. **Close the issue with the report below.** Close this issue and no other —
+   the map above it, if it has one, is not yours to touch. The runner asks
+   whether every child has landed once the whole batch is done, which is a
+   question it can answer and you cannot: you only ever see one ticket.
 
 ## The closing comment
 

--- a/ralph/ralph.config.sh.template
+++ b/ralph/ralph.config.sh.template
@@ -81,6 +81,12 @@ RALPH_BLOCK_CODE_REVIEW=1
 # session the checklist is the runner's job, which stops being true if you do.
 RALPH_VERIFY=1
 
+# When every child of a map is closed, close the map too. Ralph finds the map
+# through GitHub's native sub-issue link first, and falls back to the `## Parent`
+# section the issues in this repo actually write. It runs once per map after the
+# whole list drains, and never fails a run: a map left open costs a glance.
+RALPH_CLOSE_PARENT=1
+
 # What that checklist is: one command per entry, run in this order, each retried
 # once before it counts as red (two of these rebuild the local D1 and can col-
 # lide with a session that was just using it). Defaults to the five commands

--- a/ralph/ralph.sh
+++ b/ralph/ralph.sh
@@ -109,6 +109,9 @@ RALPH_BLOCK_CODE_REVIEW="${RALPH_BLOCK_CODE_REVIEW:-1}"
 # Run the repo's pre-commit checklist after every commit a session makes,
 # instead of taking its word that it did. Set to 0 to trust the sessions.
 RALPH_VERIFY="${RALPH_VERIFY:-1}"
+# When every child of a map is closed, close the map too. Set to 0 to leave
+# every parent for you.
+RALPH_CLOSE_PARENT="${RALPH_CLOSE_PARENT:-1}"
 # What that checklist is. Defaults to the five commands AGENTS.md names, in the
 # order CI runs them — cheap checks first, the one needing a build last.
 if [[ -z "${RALPH_CHECKLIST+x}" ]]; then
@@ -357,6 +360,79 @@ issue_advisory() {
   [[ -n "$findings" ]] || return 0
 
   printf '**#%s** — [the review](%s)\n%s\n' "$issue" "$url" "$findings"
+}
+
+# ── The map above a ticket, and closing it when its last child lands ─────────
+# This used to be the implementation session's errand — "if the issue names a
+# PRD and this was its last open child, close the PRD too" — and it never once
+# fired, for a reason worth keeping: the prompt looked for a `PRD: #NN` line
+# that no issue in this repo has ever carried. Meanwhile `RALPH.md` documented
+# that line as the mechanism, and `docs/agents/issue-tracker.md` documented
+# native sub-issues as the convention. Three conventions, none of them running.
+#
+# It is also work a script does better: "are all the siblings closed" is a
+# question with an answer, not a judgement, and asking a model to walk it costs
+# tokens to get a worse version of `wc -l`.
+#
+# issue_parent <issue> — the map's number, or empty. Native sub-issue first,
+# since that is what issue-tracker.md calls a child ticket and what GitHub can
+# answer in both directions; then the `## Parent` section every issue here
+# actually writes. One call: the native field and the body come back together.
+issue_parent() {
+  local issue="$1" raw native
+  raw="$(gh api "repos/{owner}/{repo}/issues/$issue" \
+    --jq '((.parent.number // "") | tostring) + "\n" + (.body // "")' 2>/dev/null)" || return 0
+  native="$(head -1 <<< "$raw")"
+  if [[ -n "$native" ]]; then printf '%s\n' "$native"; return 0; fi
+  awk 'NR==1{next}
+       /^##[[:space:]]+Parent/{f=1; next}
+       f && match($0, /#[0-9]+/){print substr($0, RSTART + 1, RLENGTH - 1); exit}' <<< "$raw"
+}
+
+# parent_children <parent> — "<number> <state>" per child, native first and a
+# body scan second. The scan reads every issue in the repo, which is affordable
+# here and would not be in a big one; it only runs when the map has no native
+# children at all.
+parent_children() {
+  local parent="$1" native
+  native="$(gh api "repos/{owner}/{repo}/issues/$parent/sub_issues?per_page=100" \
+    --jq '.[] | "\(.number) \(.state)"' 2>/dev/null)"
+  if [[ -n "$native" ]]; then printf '%s\n' "$native"; return 0; fi
+  gh api --paginate "repos/{owner}/{repo}/issues?state=all&per_page=100" \
+    --jq '.[] | select(.pull_request == null) | {number, state, body}' 2>/dev/null |
+    jq -r --arg p "#$parent" 'select(.body != null)
+      | select(.body | test("(^|\n)##[ \t]+Parent[ \t]*\r?\n+[ \t]*" + $p + "\\b"))
+      | "\(.number) \(.state)"'
+}
+
+# close_parent_if_done <parent> — close it only when every child has landed.
+# Never fails the run: this is bookkeeping at the end of the work, and a map
+# left open costs a glance, while a run aborted over one costs the batch.
+close_parent_if_done() {
+  local parent="$1" state children still_open lines
+  state="$(gh api "repos/{owner}/{repo}/issues/$parent" --jq .state 2>/dev/null)" || return 0
+  if [[ "$state" != "open" ]]; then return 0; fi
+
+  children="$(parent_children "$parent")"
+  if [[ -z "$children" ]]; then
+    echo "ralph: #$parent — no children found, leaving it open."
+    return 0
+  fi
+  still_open="$(awk '$2 == "open" { printf " #%s", $1 }' <<< "$children")"
+  if [[ -n "$still_open" ]]; then
+    echo "ralph: #$parent stays open —$still_open still to land."
+    return 0
+  fi
+
+  lines="$(awk '{ printf "- #%s\n", $1 }' <<< "$children")"
+  if gh issue comment "$parent" --body "Every child of this map has landed:
+
+$lines
+Closed by ralph run $RUN_TS." >/dev/null 2>&1 && gh issue close "$parent" >/dev/null 2>&1; then
+    echo "ralph: #$parent closed — every child landed."
+  else
+    echo "ralph: #$parent — could not be closed (GitHub unreadable?); close it by hand." >&2
+  fi
 }
 
 # The FIXABLE count out of a verdict line ("" when there is no line).
@@ -999,6 +1075,20 @@ for n in "${ISSUE_NUMBERS[@]}"; do
     fi
   fi
 done
+
+# Maps whose last child may have landed in this run — asked once per map, after
+# the whole list drains rather than inside it, so a batch that works three
+# siblings asks once instead of three times.
+if [[ "$RALPH_CLOSE_PARENT" == "1" && "${#PROCESSED_ISSUES[@]}" -gt 0 ]]; then
+  declare -A SEEN_PARENTS=()
+  for n in "${PROCESSED_ISSUES[@]}"; do
+    parent="$(issue_parent "$n")"
+    [[ -n "$parent" ]] || continue
+    [[ -z "${SEEN_PARENTS[$parent]:-}" ]] || continue
+    SEEN_PARENTS[$parent]=1
+    close_parent_if_done "$parent"
+  done
+fi
 
 open_pr "$WORKDIR"
 cd "$REPO_ROOT"

--- a/seed/store-expectation.ts
+++ b/seed/store-expectation.ts
@@ -120,13 +120,30 @@ function addTags(tags: Set<string>, slug: string, lang: string, values: unknown)
 }
 
 /**
- * The message a Post, a Project landing or a Series manifest fails the
- * verification with when its filename carries no recognised Locale under a
- * tree that requires one — one wording, shared by every branch that checks
- * it, rather than three copies free to drift apart (#58).
+ * A Post, a Project landing or a Series manifest whose filename carries no
+ * recognised Locale under a tree that requires one — the same fatal shape as
+ * a placement that will not classify, since this is what the file *is*, read
+ * off its path, not what it *says* (#58). One assertion, shared by the three
+ * branches that require a Locale, rather than three inline checks free to
+ * drift apart.
+ *
+ * `lang === null` leads the condition so TypeScript narrows `lang` to
+ * `string` for the caller once this returns — the `asserts lang is string`
+ * return type carries that narrowing across the function boundary, which is
+ * why every branch below can use `lang` as a string without repeating the
+ * check. A Bookmark calls none of this: it carries no Locale, so it has
+ * nothing to assert.
  */
-function noRecognisedLocale(relativePath: string, tree: ContentTree): string {
-  return `${relativePath} carries no recognised Locale — a file under ${tree}/ must end in .en.md or .es.md`;
+function assertRecognisedLocale(
+  relativePath: string,
+  tree: ContentTree,
+  lang: string | null,
+): asserts lang is string {
+  if (lang === null || !localeMatchesTree(tree, lang)) {
+    throw new Error(
+      `${relativePath} carries no recognised Locale — a file under ${tree}/ must end in .en.md or .es.md`,
+    );
+  }
 }
 
 /** Where a Part sits, as its Series manifest lists it: its Section and its position in that list. */
@@ -231,15 +248,7 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
     const { slug, lang } = parsed;
 
     if (placed.type === "post") {
-      // `lang === null` leads the condition so TypeScript narrows `lang` to
-      // `string` below — the same reason `series-sql.ts` and `project-sql.ts`
-      // write the check this way. A filename carrying no recognised Locale
-      // under a tree that requires one is the same fatal shape as a
-      // placement that will not classify — it is what the file *is*, not
-      // what it *says* — so it stops the run too (#58).
-      if (lang === null || !localeMatchesTree(placed.tree, lang)) {
-        throw new Error(noRecognisedLocale(relativePath, placed.tree));
-      }
+      assertRecognisedLocale(relativePath, placed.tree, lang);
 
       expectation.content.add(`${slug}:${lang}`);
       addTags(expectation.contentTags, slug, lang, attributes.tags);
@@ -271,16 +280,12 @@ export function expectationFrom(documents: DocumentInput[]): Expectation {
     } else if (placed.type === "project") {
       // A Project is not a Content Item — no Published At, no place in the
       // Timeline — so it is its own set, keyed the same way `project-sql.ts`
-      // keys the row it seeds. No recognised Locale is fatal here too (#58).
-      if (lang === null || !localeMatchesTree(placed.tree, lang)) {
-        throw new Error(noRecognisedLocale(relativePath, placed.tree));
-      }
+      // keys the row it seeds.
+      assertRecognisedLocale(relativePath, placed.tree, lang);
 
       expectation.project.add(`${slug}:${lang}`);
     } else if (placed.type === "series") {
-      if (lang === null || !localeMatchesTree(placed.tree, lang)) {
-        throw new Error(noRecognisedLocale(relativePath, placed.tree));
-      }
+      assertRecognisedLocale(relativePath, placed.tree, lang);
 
       expectation.series.add(`${slug}:${lang}`);
 
@@ -351,6 +356,15 @@ export interface SectionOrderFinding {
  * Section's own position in the arc is a value on a row that already
  * exists, not a presence set. An identity missing from `present` is skipped
  * here too — the presence comparison for Sections already names it missing.
+ *
+ * Kept separate from `compareContainers` on purpose, not by oversight: the
+ * two compare different shapes — a record of four Container columns against
+ * a single position — and their findings carry different fields, a
+ * `ContainerFinding` naming the column that disagreed where a
+ * `SectionOrderFinding` has no column to name. A comparator generic over
+ * both would need a column list and a finding constructor, which costs more
+ * to audit than the dozen lines it saves, in a script whose value is being
+ * obviously correct by inspection.
  */
 export function compareSectionOrder(
   expected: Map<string, number>,

--- a/seed/verify-stores.ts
+++ b/seed/verify-stores.ts
@@ -160,8 +160,10 @@ async function verify(mode: string): Promise<boolean> {
     // wrong in either direction: the presence check below would pass and
     // certify an empty `content` table. `generate-seed-sql.ts` already treats
     // this state as impossible; the verifier now agrees (#58).
-    passed = report("Content Item expectation is not empty", !isEmptyContentExpectation(expected),
-        isEmptyContentExpectation(expected)
+    const contentExpectationIsEmpty = isEmptyContentExpectation(expected);
+
+    passed = report("Content Item expectation is not empty", !contentExpectationIsEmpty,
+        contentExpectationIsEmpty
             ? "derived to nothing — a broken derivation would certify an empty store"
             : `${expected.content.size} expected`) && passed;
 

--- a/tests/unit/seed/store-expectation.test.ts
+++ b/tests/unit/seed/store-expectation.test.ts
@@ -158,6 +158,7 @@ describe("expectationFrom — placement and Locale", () => {
 
     const expectation = expectationFrom(docs);
 
+    expect(expectation.project).toEqual(new Set(["chekalo:en"]));
     expect(expectation.content.size).toBe(0);
     expect(expectation.series.size).toBe(0);
   });
@@ -299,6 +300,25 @@ describe("expectationFrom — the Container columns", () => {
     ];
 
     expect(expectationFrom(docs).containers.get("onboarding-flow:en")?.containerOrder).toBe(1);
+  });
+
+  /**
+   * Settles #56's own review, where the Spec axis called this a gap and the
+   * Tests axis called the suite sound: the loose-Post test above covers the
+   * same empty-Container shape, but a Bookmark reaches it through a different
+   * branch and under a different identity — Slug with an empty Locale, not
+   * Slug with a Locale. Asserting the identity, not only the columns, is what
+   * catches a mis-keyed entry rather than only a missing one.
+   */
+  it("expects a Bookmark to have no Container, keyed by its Slug with an empty Locale", () => {
+    const docs = [document("bookmarks/how-i-would-do-auth.md")];
+
+    expect(expectationFrom(docs).containers.get("how-i-would-do-auth:")).toEqual({
+      seriesSlug: null,
+      seriesSection: null,
+      projectSlug: null,
+      containerOrder: null,
+    });
   });
 });
 


### PR DESCRIPTION
Autonomous run — issues in this PR:
- #61 The duplication the verifier sequence left behind, and two tests that promise more than they check

## Advisory — raised, and deliberately not acted on

The review sessions found these and left them alone on purpose: smells, scope
creep, weak tests, judgement calls. **This is the moment to decide on them** —
you have the diff in front of you. Whatever you don't act on here goes back to
being findable only in a comment on a closed issue, so decide rather than defer:
open a ticket for what should outlive this PR, and let the rest go on purpose.

**#61** — [the review](https://github.com/poschuler/poschuler.com/issues/61#issuecomment-5320870562)
- Standards (JUDGEMENT): `assertRecognisedLocale`'s `asserts lang is string` pattern is new to this codebase — no prior `asserts` function exists under `seed/`, `app/`, or `tests/`. Not a violation of any documented rule; noted as a first-of-its-kind idiom worth being aware of.
- Standards (JUDGEMENT): `assertRecognisedLocale(relativePath, tree, lang)` travels as a fixed three-parameter clump across all three call sites — a possible Data Clump, but weak enough the reviewing agent itself concluded the repo's own stated philosophy (avoid generalizing for costs that aren't there) argues against bundling it.

Draft — review, then merge into `dev`.